### PR TITLE
Allow Policy to be overwritten for testing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,3 @@
-// Copyright 2024 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 module github.com/google/gce-tcb-verifier
 
 go 1.19


### PR DESCRIPTION
The go.mod license header is also causing problems with a parser, and not necessary.