### PR TITLE
Add endorsement extraction from RIM events in event logs

### DIFF
--- a/extract/eventlog/efivar.go
+++ b/extract/eventlog/efivar.go
@@ -1,0 +1,118 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventlog
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/google/uuid"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// VariableReader provides a method of reading UEFI variable contents given the
+// vendor GUID and CHAR16 variable name. The UEFI specification states that strings
+// are encoded in UCS-2.
+type VariableReader interface {
+	ReadVariable(guid uuid.UUID, name []uint8) ([]byte, error)
+}
+
+// EfiVarFSReader implements VariableReader for the Linux efivarfs interface to UEFI
+// variables.
+type EfiVarFSReader struct {
+	// Root is the mount location of the efivarfs volume.
+	Root string
+}
+
+// Returns an error if any rune of utf8encoding is unrepresentable in UCS-2.
+// Uses the ucs2encoding for context in error messages.
+func validateUCS2Codepoints(ucs2encoding, utf8encoding []byte) error {
+	read := bytes.NewBuffer(utf8encoding)
+	for {
+		r, n, err := read.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		// Bad encoding
+		if r == 0xFFFD && n == 1 {
+			return fmt.Errorf("could not decode UCS-2 name %v", ucs2encoding)
+		}
+		if r > 0xFFFF {
+			return fmt.Errorf("codepoint 0x%x is unrepresentable in UCS-2", r)
+		}
+	}
+	return nil
+}
+
+// ucs2toUTF8 translates a string in UCS-2 encoding to UTF-8 by first
+// interpreting the string as UTF-16 and then rejecting runes unrepresentable
+// in UCS-2, i.e., codepoints greater than 65535.
+func ucs2toUTF8(name []uint8) (string, error) {
+	e := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+	utf8encoding, _, err := transform.Bytes(e.NewDecoder(), name)
+	if err != nil {
+		return "", fmt.Errorf("could not decode UCS-2: %v", err)
+	}
+	// Remove null terminator if one exists.
+	if utf8encoding[len(utf8encoding)-1] == 0 {
+		utf8encoding = utf8encoding[:len(utf8encoding)-1]
+	}
+	if err := validateUCS2Codepoints(name, utf8encoding); err != nil {
+		return "", err
+	}
+	return string(utf8encoding), nil
+}
+
+func (r *EfiVarFSReader) varBasename(guid uuid.UUID, name []uint8) (string, error) {
+	// Note that at time of writing, Linux does not correctly translate the UTF-8
+	// path to UCS-2 VariableName when parsing the efivarfs path.
+	basename, err := ucs2toUTF8(name)
+	if err != nil {
+		return "", err
+	}
+	path, err := securejoin.SecureJoin(r.Root, fmt.Sprintf("%s-%s", basename, guid))
+	if err != nil {
+		return "", fmt.Errorf("variable name evaluated to illegal path: %v", err)
+	}
+	return path, nil
+}
+
+// ReadVariable returns the contents of a UEFI variable using Linux's efivarfs volume
+// represented in r.Root. The name is in UEFI-native UCS-2 encoding. We use the UTF-16
+// decoder because UCS-2 and UTF-16 use the same encoding for code points representable
+// in 16 bits.
+func (r *EfiVarFSReader) ReadVariable(guid uuid.UUID, name []uint8) ([]byte, error) {
+	path, err := r.varBasename(guid, name)
+	if err != nil {
+		return nil, err
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(contents) < 4 {
+		return nil, fmt.Errorf("variable contents ill-formed. %v does not start with 4-byte attribute header", contents)
+	}
+	return contents[4:], nil
+}
+
+// MakeEfiVarFSReader returns a Linux efivarfs UEFI variable reader
+func MakeEfiVarFSReader(root string) *EfiVarFSReader {
+	return &EfiVarFSReader{Root: root}
+}

--- a/extract/eventlog/eventlog.go
+++ b/extract/eventlog/eventlog.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package eventlog provides utilities for interpreting Canonical Event Log events.
+package eventlog
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"unicode/utf16"
+
+	"github.com/google/gce-tcb-verifier/eventlog"
+	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
+	"github.com/google/go-sev-guest/verify/trust"
+)
+
+// ErrLocateGetterNil is returned when a LocateOptions.Getter is nil.
+var ErrLocateGetterNil = errors.New("locate getter is nil")
+
+// LocateOptions contains options for locating data that can be local or remote.
+type LocateOptions struct {
+	Getter               trust.HTTPSGetter
+	EfiVarsMountLocation string
+}
+
+// DefaultLocateOptions returns a default LocateOptions.
+func DefaultLocateOptions() *LocateOptions {
+	return &LocateOptions{
+		Getter:               trust.DefaultHTTPSGetter(),
+		EfiVarsMountLocation: "/sys/firmware/efi/efivars",
+	}
+}
+
+// variableLocatorPath reads a UEFI variable name from a RIM locator of variable type.
+func variableLocatorPath(dst *string, data []byte) error {
+	// 16 for guid, 2 for 00-terminator.
+	if len(data) <= 18 {
+		return fmt.Errorf("variable name is too short: %d bytes", len(data))
+	}
+	guid, err := oabi.FromEFIGUID(data[:16])
+	if err != nil {
+		return err
+	}
+	name := data[16:] // at least size 1
+	if len(name)%2 != 0 {
+		return fmt.Errorf("couldn't read variable name as UTF-16 string: %v", name)
+	}
+	if !(name[len(name)-1] == 0 && name[len(name)-2] == 0) {
+		return fmt.Errorf("couldn't read variable name as 00-terminated UTF-16 string")
+	}
+	utf16name := name[:len(name)-2]
+
+	str := make([]uint16, len(utf16name)/2)
+	for i := 0; i < len(utf16name); i += 2 {
+		str[i/2] = binary.LittleEndian.Uint16(utf16name[i : i+2])
+	}
+	*dst = fmt.Sprintf("%s-%s", string(utf16.Decode(str)), guid)
+	return nil
+}
+
+// Locate returns the value of a RIM locator.
+func Locate(locType uint32, loc []byte, opts *LocateOptions) ([]byte, error) {
+	switch locType {
+	case eventlog.RIMLocationRaw:
+		return loc, nil
+	case eventlog.RIMLocationURI:
+		if opts.Getter == nil {
+			return nil, ErrLocateGetterNil
+		}
+		return opts.Getter.Get(string(loc))
+	case eventlog.RIMLocationVariable:
+		var basename string
+		err := variableLocatorPath(&basename, loc)
+		if err != nil {
+			return nil, err
+		}
+		return os.ReadFile(path.Join(opts.EfiVarsMountLocation, basename))
+	default:
+		return nil, fmt.Errorf("unsupported locator type: %v", locType)
+	}
+}
+
+// RIMEventsFromEventLog returns a map of RIM locator type to a slice of SP800-155 Event3 events
+// that match the RIM locator type.
+func RIMEventsFromEventLog(el *eventlog.CryptoAgileLog) map[uint32][]*eventlog.SP800155Event3 {
+	result := make(map[uint32][]*eventlog.SP800155Event3)
+	for _, evt := range el.Events {
+		if evt.EventType != eventlog.EvNoAction {
+			continue
+		}
+		sp800155, ok := evt.EventData.Event.(*eventlog.SP800155Event3)
+		if !ok {
+			continue
+		}
+		result[sp800155.RIMLocatorType] = append(result[sp800155.RIMLocatorType], sp800155)
+	}
+	return result
+}

--- a/extract/eventlog/eventlog_test.go
+++ b/extract/eventlog/eventlog_test.go
@@ -1,0 +1,242 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventlog
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/gce-tcb-verifier/eventlog"
+	"github.com/google/gce-tcb-verifier/testing/match"
+	"github.com/google/go-cmp/cmp"
+	test "github.com/google/go-sev-guest/testing"
+)
+
+const (
+	myGUID  = "6a7b6885-92bc-40cd-9fb5-300f9d1eb0ed"
+	rimGUID = "c51b6d7f-9c2a-42d6-be47-ca1368bdc333"
+)
+
+var myEfiGUID []byte = []byte{0x85, 0x68, 0x7b, 0x6a, 0xbc, 0x92, 0xcd, 0x40, 0x9f, 0xb5, 0x30, 0x0f, 0x9d, 0x1e, 0xb0, 0xed}
+
+func TestUEFIVariable(t *testing.T) {
+	tcs := []struct {
+		name    string
+		data    []byte
+		want    string
+		wantErr string
+	}{
+		{
+			name: "happy path",
+			data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0, 0),
+			want: "Var-" + myGUID,
+		},
+		{
+			name:    "odd length",
+			data:    append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0),
+			wantErr: "couldn't read variable name as UTF-16 string",
+		},
+		{
+			name:    "bad terminator no zeros",
+			data:    append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0),
+			wantErr: "00-terminated UTF-16 string",
+		},
+		{
+			name:    "too short",
+			data:    []byte{0, 1},
+			wantErr: "too short: 2 bytes",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var out string
+			if err := variableLocatorPath(&out, tc.data); !match.Error(err, tc.wantErr) {
+				t.Fatalf("variableLocatorPath(_, %v) = %v errored unexpectedly. Want %q", tc.data, err, tc.wantErr)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if out != tc.want {
+				t.Errorf("variableLocatorPath(_, %v) wrote %q, want %q", tc.data, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestLocate(t *testing.T) {
+	dir := t.TempDir()
+	varloc := path.Join(dir, "Var-"+myGUID)
+	err := os.WriteFile(varloc, []byte{0xc0, 0xde}, 0644)
+	if err != nil {
+		t.Fatalf("os.WriteFile(%q) = %v, want nil", varloc, err)
+	}
+	tcs := []struct {
+		name    string
+		loctype uint32
+		loc     []byte
+		opts    *LocateOptions
+		want    []byte
+		wantErr string
+	}{
+		{
+			name:    "happy raw",
+			loctype: eventlog.RIMLocationRaw,
+			loc:     []byte{0xc0, 0xde},
+			opts:    &LocateOptions{},
+			want:    []byte{0xc0, 0xde},
+		},
+		{
+			name:    "happy uri",
+			loctype: eventlog.RIMLocationURI,
+			loc:     []byte("uri"),
+			opts: &LocateOptions{
+				Getter: test.SimpleGetter(map[string][]byte{
+					"uri": {0xc0, 0xde},
+				}),
+			},
+			want: []byte{0xc0, 0xde},
+		},
+		{
+			name:    "uri 404",
+			loctype: eventlog.RIMLocationURI,
+			loc:     []byte("uri"),
+			opts: &LocateOptions{
+				Getter: test.SimpleGetter(map[string][]byte{}),
+			},
+			wantErr: "404",
+		},
+		{
+			name:    "uri no getter",
+			loctype: eventlog.RIMLocationURI,
+			loc:     []byte("uri"),
+			opts:    &LocateOptions{},
+			wantErr: ErrLocateGetterNil.Error(),
+		},
+		{
+			name:    "happy variable",
+			loc:     append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0, 0),
+			loctype: eventlog.RIMLocationVariable,
+			opts: &LocateOptions{
+				EfiVarsMountLocation: dir,
+			},
+			want: []byte{0xc0, 0xde},
+		},
+		{
+			name:    "unhappy variable",
+			loc:     []byte{0xc0, 0xde},
+			loctype: eventlog.RIMLocationVariable,
+			wantErr: "variable name is too short: 2 bytes",
+		},
+		{
+			name:    "unsupported locator",
+			loctype: 999,
+			wantErr: "unsupported locator type: 999",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Locate(tc.loctype, tc.loc, tc.opts)
+			if !match.Error(err, tc.wantErr) {
+				t.Fatalf("Locate(%v, %v, %v) errored unexpectedly. Got %v, want %q", tc.loctype,
+					tc.loc, tc.opts, err, tc.wantErr)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("Locate(%v, %v, %v) returned diff (-got +want):\n%s", tc.loctype,
+					tc.loc, tc.opts, diff)
+			}
+		})
+	}
+}
+
+func TestRimEventsFromEventLog(t *testing.T) {
+	tests := []struct {
+		name string
+		el   *eventlog.CryptoAgileLog
+		want map[uint32][]*eventlog.SP800155Event3
+	}{
+		{
+			name: "happy path",
+			el: &eventlog.CryptoAgileLog{
+				Header: eventlog.TCGPCClientPCREvent{
+					PCRIndex:  1,
+					EventType: 10,
+					EventData: eventlog.TCGEventData{Event: &eventlog.UnknownEvent{}},
+				},
+				Events: []*eventlog.TCGPCREvent2{
+					{EventType: 99},
+					{
+						EventType: eventlog.EvNoAction,
+						EventData: eventlog.TCGEventData{Event: &eventlog.UnknownEvent{}},
+					},
+					{
+						EventType: eventlog.EvNoAction,
+						EventData: eventlog.TCGEventData{
+							Event: &eventlog.SP800155Event3{
+								RIMLocatorType: eventlog.RIMLocationVariable,
+								RIMLocator:     eventlog.Uint32SizedArray{Data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0, 0)},
+							}},
+					},
+					{
+						EventType: eventlog.EvNoAction,
+						EventData: eventlog.TCGEventData{
+							Event: &eventlog.SP800155Event3{
+								RIMLocatorType: eventlog.RIMLocationVariable,
+								RIMLocator:     eventlog.Uint32SizedArray{Data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, '2', 0, 0, 0)},
+							}},
+					},
+					{
+						EventType: eventlog.EvNoAction,
+						EventData: eventlog.TCGEventData{
+							Event: &eventlog.SP800155Event3{
+								RIMLocatorType: eventlog.RIMLocationURI,
+								RIMLocator:     eventlog.Uint32SizedArray{Data: []byte("https://example.com")},
+							}},
+					},
+				},
+			},
+			want: map[uint32][]*eventlog.SP800155Event3{
+				eventlog.RIMLocationVariable: {
+					{
+						RIMLocatorType: eventlog.RIMLocationVariable,
+						RIMLocator:     eventlog.Uint32SizedArray{Data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0, 0)},
+					},
+					{
+						RIMLocatorType: eventlog.RIMLocationVariable,
+						RIMLocator:     eventlog.Uint32SizedArray{Data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, '2', 0, 0, 0)},
+					},
+				},
+				eventlog.RIMLocationURI: {
+					{
+						RIMLocatorType: eventlog.RIMLocationURI,
+						RIMLocator:     eventlog.Uint32SizedArray{Data: []byte("https://example.com")},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RIMEventsFromEventLog(tc.el)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("RIMEventsFromEventLog(%v) returned an unexpected diff (-want +got): %v", tc.el, diff)
+			}
+		})
+	}
+}

--- a/gcetcbendorsement/cmd/cmd_test.go
+++ b/gcetcbendorsement/cmd/cmd_test.go
@@ -41,6 +41,7 @@ import (
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	test "github.com/google/go-sev-guest/testing"
 	testclient "github.com/google/go-sev-guest/testing/client"
+	"github.com/google/go-sev-guest/verify/trust"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -50,8 +51,8 @@ import (
 var (
 	mu               sync.Once
 	qp               extract.QuoteProvider
-	getter           extract.HTTPSGetter
-	rootlessGetter   extract.HTTPSGetter
+	getter           trust.HTTPSGetter
+	rootlessGetter   trust.HTTPSGetter
 	now              time.Time
 	goodQuote        []byte
 	fakeEndorsement  []byte
@@ -404,7 +405,7 @@ func TestVerify(t *testing.T) {
 	tcs := []struct {
 		name    string
 		input   []string
-		getter  extract.HTTPSGetter
+		getter  trust.HTTPSGetter
 		io      *testIO
 		wantErr string
 		want    []byte
@@ -531,7 +532,7 @@ func TestSevPolicy(t *testing.T) {
 	tcs := []struct {
 		name    string
 		input   []string
-		getter  extract.HTTPSGetter
+		getter  trust.HTTPSGetter
 		io      *testIO
 		want    func(got []byte) error
 		wantErr string
@@ -635,7 +636,7 @@ func TestSevValidate(t *testing.T) {
 	tcs := []struct {
 		name    string
 		input   []string
-		getter  extract.HTTPSGetter
+		getter  trust.HTTPSGetter
 		io      *testIO
 		wantErr string
 	}{

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/iam v1.1.6
 	cloud.google.com/go/kms v1.15.7
+	github.com/cyphar/filepath-securejoin v0.2.5
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-sev-guest v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go/iam v1.1.6/go.mod h1:O0zxdPeGBoFdWW3HWmBxJsk0pfvNM/p/qa82rWO
 cloud.google.com/go/kms v1.15.7 h1:7caV9K3yIxvlQPAcaFffhlT7d1qpxjB1wHBtjWa13SM=
 cloud.google.com/go/kms v1.15.7/go.mod h1:ub54lbsa6tDkUwnu4W7Yt1aAIFLnspgh0kPGToDukeI=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cyphar/filepath-securejoin v0.2.5 h1:6iR5tXJ/e6tJZzzdMc1km3Sa7RRIVBKAK32O2s7AYfo=
+github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=


### PR DESCRIPTION
Depends on https://github.com/google/gce-tcb-verifier/pull/8

Looks for the TcgSP800155Event3 event type and interprets the RIM locator type associated to get the reference integrity manifest (VMLaunchEndorsement on GCE).