### PR TITLE
Add gcetcbendorsement CLI entrypoint

### DIFF
--- a/gcetcbendorsement/cli/main.go
+++ b/gcetcbendorsement/cli/main.go
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The gcetcbendorsement command provides a CLI tool for interpreting the UEFI binary endorsement.
+package main
+
+import (
+	"os"
+
+	"github.com/google/gce-tcb-verifier/gcetcbendorsement/cmd"
+)
+
+func main() {
+	if cmd.RootCmd.Execute() != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Missed the main() definition on initial export.