### PR TITLE
Add a release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  push:
+    branches:
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        go-version: [1.20.x]
+        os: [ubuntu-latest]
+
+    name: Release for (${{ matrix.os}}, Go ${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          path: dist/${{ matrix.os }}
+          key: ${{ matrix.go }}-${{ env.sha_short }}
+      - name: Build gcetcbendorsement
+        run: mkdir bin && go build -o bin/gcetcbendorsement -v ./gcetcbendorsement/cli
+      - name: Build non-production example endorse tool
+        run: go build -o bin/endorsenonprod -v ./cmd/nonprod
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        if: success() && startsWith(github.ref, 'refs/tags/') && steps.cache.outputs.cache-hit != 'true'
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/nonprod/main.go
+++ b/cmd/nonprod/main.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The nonprod command provides a non-production CLI tool for endorsing an input UEFI binary and
+// managing the keys to do so.
+package main
+
+import (
+	"os"
+
+	"github.com/google/gce-tcb-verifier/testing/nonprod"
+)
+
+func main() {
+	if nonprod.RootCmd.Execute() != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Also add the missing nonprod CLI binary definition. Both locations for the binaries aren't named recognizably as released binaries, so the release configuration explicitly names the two tools.