### PR TITLE
Add SP800155 event generation.

### DIFF
--- a/endorse/sp800155.go
+++ b/endorse/sp800155.go
@@ -76,7 +76,7 @@ func uriEventHOB(rimGUID eventlog.EfiGUID, digest []byte) []byte {
 	// This will need to not be hardcoded when we're signing multiple builds at a time, but for now
 	// this works.
 	obj := fmt.Sprintf("ovmf_x64_csm/%s.fd.signed", hex.EncodeToString(digest))
-	return spHOB(googleSp800155Event(rimGUID, eventlog.RIMLocationURI, []byte(verify.GceTcbURL(obj))))
+	return spHOB(googleSp800155Event(rimGUID, eventlog.RIMLocationURI, []byte(verify.GCETcbURL(obj))))
 }
 
 // makeEvents returns the boot service UEFI variable contents the firmware will use to populate the

--- a/endorse/sp800155.go
+++ b/endorse/sp800155.go
@@ -1,0 +1,99 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endorse
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/google/gce-tcb-verifier/eventlog"
+	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
+	epb "github.com/google/gce-tcb-verifier/proto/endorsement"
+	"github.com/google/gce-tcb-verifier/verify"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	googleEfiVariable  = "a2858e46-a37f-456a-8c79-0c1fe48b65ff"
+	sp800155Variable   = "FirmwareRIM"  // defined only for test comparison with rimVar
+	googleID           = 11129          // IANA PEN
+	googleManufacturer = "Google, Inc." // IANA PEN text
+	platformModel      = "Google Compute Engine"
+)
+
+var (
+	rimVar = []byte{
+		0x46, 0x8e, 0x85, 0xa2, 0x7f, 0xa3, 0x6a, 0x45, 0x8c, 0x79, 0x0c, 0x1f, 0xe4, 0x8b, 0x65, 0xff,
+		'F', 0, 'i', 0, 'r', 0, 'm', 0, 'w', 0, 'a', 0, 'r', 0, 'e', 0,
+		'R', 0, 'I', 0, 'M', 0, 0, 0,
+	}
+
+	sp800155guid = uuid.MustParse(oabi.Tcg800155PlatformIDEventHobGUID)
+)
+
+func googleSp800155Event(rimGUID eventlog.EfiGUID, locType uint32, loc []byte) *eventlog.SP800155Event3 {
+	return &eventlog.SP800155Event3{
+		PlatformManufacturerID:  11129,
+		ReferenceManifestGUID:   rimGUID,
+		PlatformManufacturerStr: eventlog.ByteSizedArray{Data: []byte(googleManufacturer)},
+		PlatformModel:           eventlog.ByteSizedArray{Data: []byte(platformModel)},
+		FirmwareManufacturerStr: eventlog.ByteSizedArray{Data: []byte(googleManufacturer)},
+		FirmwareManufacturerID:  11129,
+		RIMLocatorType:          locType,
+		RIMLocator:              eventlog.Uint32SizedArray{Data: loc},
+	}
+}
+
+func spHOB(sp *eventlog.SP800155Event3) []byte {
+	evt, _ := sp.MarshalToBytes()
+	// Impossible to exceed a page with the given event.
+	hob, _ := oabi.CreateEFIHOBGUID(sp800155guid, evt)
+	evtb := bytes.NewBuffer(nil)
+	hob.WriteTo(evtb)
+	return evtb.Bytes()
+}
+
+func varEventHOB(rimGUID eventlog.EfiGUID) []byte {
+	return spHOB(googleSp800155Event(rimGUID, eventlog.RIMLocationVariable, rimVar))
+}
+
+func uriEventHOB(rimGUID eventlog.EfiGUID, digest []byte) []byte {
+	// This will need to not be hardcoded when we're signing multiple builds at a time, but for now
+	// this works.
+	obj := fmt.Sprintf("ovmf_x64_csm/%s.fd.signed", hex.EncodeToString(digest))
+	return spHOB(googleSp800155Event(rimGUID, eventlog.RIMLocationURI, []byte(verify.GceTcbURL(obj))))
+}
+
+// makeEvents returns the boot service UEFI variable contents the firmware will use to populate the
+// PEI HOB list with Tcg800155PlatformIdEvents
+func makeEvents(random io.Reader, endorsement *epb.VMLaunchEndorsement) ([]byte, error) {
+	golden := &epb.VMGoldenMeasurement{}
+	// error not checked since it has been deserialized before getting here.
+	proto.Unmarshal(endorsement.GetSerializedUefiGolden(), golden)
+	rimUUID, err := uuid.NewRandomFromReader(random)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RIM UUID: %v", err)
+	}
+	rimGUID := eventlog.EfiGUID{UUID: rimUUID}
+	// We create 2 events: point to the uefi variable and point to the URI.
+	result := append(varEventHOB(rimGUID), uriEventHOB(rimGUID, golden.GetDigest())...)
+	if len(result) > oabi.PageSize {
+		return nil, fmt.Errorf("SP800155 events too large: %d", len(result))
+	}
+	return result, nil
+}

--- a/endorse/sp800155_test.go
+++ b/endorse/sp800155_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package endorse
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/google/gce-tcb-verifier/eventlog"
+	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
+	epb "github.com/google/gce-tcb-verifier/proto/endorsement"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/proto"
+)
+
+func combine(base []byte, rest ...[]byte) []byte {
+	combined := base
+	for _, bs := range rest {
+		combined = append(combined, bs...)
+	}
+	return combined
+}
+
+// Intended encoding vs illegible hardcoded array.
+func TestRimVar(t *testing.T) {
+	var efiGUID [16]byte
+	oabi.PutUUID(efiGUID[:], uuid.MustParse(googleEfiVariable))
+	want := efiGUID[:]
+	for _, c := range []byte(sp800155Variable) {
+		want = binary.LittleEndian.AppendUint16(want, uint16(c))
+	}
+	want = append(want, 0, 0)
+	if !bytes.Equal(rimVar, want) {
+		t.Errorf("rimVar = %v, want %v", rimVar, want)
+	}
+}
+
+func TestMakeEvents(t *testing.T) {
+	var digest [48]byte
+	for i := byte(0); i < 48; i++ {
+		digest[i] = i
+	}
+	golden := &epb.VMGoldenMeasurement{Digest: digest[:]}
+	goldenBytes, _ := proto.Marshal(golden)
+	e := &epb.VMLaunchEndorsement{SerializedUefiGolden: goldenBytes}
+	rimGUIDsrc := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	// Version 4 Variant 10, so 7th and 9th bytes get modified.
+	rimEFIGUID := []byte{3, 2, 1, 0, 5, 4, 0x7, 0x46, 0x88, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
+	blob, err := makeEvents(bytes.NewBuffer(rimGUIDsrc), e)
+	if err != nil {
+		t.Fatalf("makeEvents(%v) failed: %v", e, err)
+	}
+	tcg := uuid.MustParse(oabi.Tcg800155PlatformIDEventHobGUID)
+	var tcgEFIGUID [16]byte
+	oabi.PutUUID(tcgEFIGUID[:], tcg)
+	varHob := combine([]byte{0x04, 0x00, 0xb0, 0x00, 0x00, 0x00, 0x00, 0x00}, // HOB generic header
+		tcgEFIGUID[:],
+		[]byte("SP800-155 Event3"),
+		binary.LittleEndian.AppendUint32(nil, 11129), // PlatformManufacturerID
+		rimEFIGUID,                                   // ReferenceManifestGuid
+		append([]byte{byte(len(googleManufacturer))}, []byte(googleManufacturer)...), // PlatformManufacturerStr
+		append([]byte{byte(len(platformModel))}, []byte(platformModel)...),           // PlatformModel
+		[]byte{0}, // PlatformVersion
+		append([]byte{byte(len(googleManufacturer))}, []byte(googleManufacturer)...), // FirmwareManufacturerStr
+		binary.LittleEndian.AppendUint32(nil, 11129),                                 // FirmwareManufacturerID
+		[]byte{0}, // FirmwareVersion
+		binary.LittleEndian.AppendUint32(nil, eventlog.RIMLocationVariable), // RIM locator type
+		binary.LittleEndian.AppendUint32(nil, uint32(len(rimVar))),          // RIM locator (length)
+		rimVar,             // Rim locator (data)
+		[]byte{0, 0, 0, 0}, // Platform cert locator type
+		[]byte{0, 0, 0, 0}, // Platform cert length
+	)
+	if len(varHob) != 170 {
+		t.Errorf("varHob = %v, want length 170", varHob)
+	}
+	if diff := cmp.Diff(varHob, blob[:170]); diff != "" {
+		t.Errorf("makeEvents(%v) = %v..., want %v...: diff (-want, +got) %s", e, blob[:192], varHob, diff)
+	}
+	if len(blob) != 480 {
+		t.Errorf("makeEvents(%v) = %v, want length 480", e, len(blob))
+	}
+}

--- a/eventlog/event.go
+++ b/eventlog/event.go
@@ -83,10 +83,9 @@ func (d *TCGEventData) Unmarshal(r io.Reader) error {
 			return nil
 		}
 		d.Event = factory()
-		d.Event.UnmarshalFromBytes(chunk[EventSignatureSize:])
-	} else {
-		d.Event = &UnknownEvent{Data: chunk}
+		return d.Event.UnmarshalFromBytes(chunk[EventSignatureSize:])
 	}
+	d.Event = &UnknownEvent{Data: chunk}
 	return nil
 }
 

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -148,7 +148,7 @@ func fromSevSnpAttestationProto(at *spb.Attestation) ([]byte, string, error) {
 		return out, "", nil
 	}
 	meas := at.GetReport().GetMeasurement()
-	return nil, extractsev.GceTcbObjectName(sev.GCEUefiFamilyID, meas), nil
+	return nil, extractsev.GCETcbObjectName(sev.GCEUefiFamilyID, meas), nil
 }
 
 func fromTdxAttestationProto(at *tpb.QuoteV4) string {
@@ -264,7 +264,7 @@ func Endorsement(opts *Options) (out []byte, err error) {
 	if opts.Getter == nil {
 		internetErr = ErrGetterNil
 	} else {
-		endorsement, internetErr = opts.Getter.Get(verify.GceTcbURL(objectName))
+		endorsement, internetErr = opts.Getter.Get(verify.GCETcbURL(objectName))
 		if internetErr == nil {
 			return endorsement, nil
 		}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -30,11 +30,13 @@ import (
 	"github.com/google/gce-tcb-verifier/eventlog"
 	exel "github.com/google/gce-tcb-verifier/extract/eventlog"
 	"github.com/google/gce-tcb-verifier/extract/extractsev"
+	"github.com/google/gce-tcb-verifier/extract/extracttdx"
 	"github.com/google/gce-tcb-verifier/sev"
 	"github.com/google/gce-tcb-verifier/verify"
 	"github.com/google/go-sev-guest/abi"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/google/go-sev-guest/verify/trust"
+	tpb "github.com/google/go-tdx-guest/proto/tdx"
 	tpmpb "github.com/google/go-tpm-tools/proto/attest"
 	"go.uber.org/multierr"
 	"google.golang.org/protobuf/proto"
@@ -119,31 +121,26 @@ func (opts *Options) fromEventLog() ([]byte, error) {
 		return nil, err
 	}
 	evts := exel.RIMEventsFromEventLog(el)
-	// Raw data takes precedence over UEFI variables.
-	if raws, ok := evts[eventlog.RIMLocationRaw]; ok && len(raws) != 0 {
-		for _, evt := range raws {
-			if bytes.Equal(evt.FirmwareManufacturerStr.Data, opts.FirmwareManufacturer) {
-				return evt.RIMLocator.Data, nil
+	locopts := &exel.LocateOptions{
+		Getter:             opts.Getter,
+		UEFIVariableReader: opts.UEFIVariableReader,
+	}
+	for _, evts := range [][]*eventlog.SP800155Event3{
+		// Raw data takes precedence over UEFI variables.
+		evts[eventlog.RIMLocationRaw],
+		// UEFI variables take precedence over local device paths.
+		evts[eventlog.RIMLocationVariable],
+		// UEFI local device paths take precedence over URIs.
+		evts[eventlog.RIMLocationLocal],
+		// Finally reach out to the network.
+		evts[eventlog.RIMLocationURI]} {
+		for _, evt := range evts {
+			if len(opts.FirmwareManufacturer) == 0 || bytes.Equal(evt.FirmwareManufacturerStr.Data, opts.FirmwareManufacturer) {
+				return exel.Locate(evt.RIMLocatorType, evt.RIMLocator.Data, locopts)
 			}
 		}
 	}
-
-	// UEFI variables take precedence over URIs
-	if vars, ok := evts[eventlog.RIMLocationVariable]; ok && len(vars) != 0 {
-		for _, evt := range vars {
-			// No specific firmware manufacturer => get the first event.
-			if len(opts.FirmwareManufacturer) == 0 ||
-				bytes.Equal(evt.FirmwareManufacturerStr.Data, opts.FirmwareManufacturer) {
-				return exel.Locate(evt.RIMLocatorType, evt.RIMLocator.Data, &exel.LocateOptions{
-					Getter:             opts.Getter,
-					UEFIVariableReader: opts.UEFIVariableReader,
-				})
-			}
-		}
-	}
-
-	// If the RimLocatorType is URI, local UEFI device, or UEFI variable
-	return nil, fmt.Errorf("unimplemented")
+	return nil, fmt.Errorf("matching sp800155 firmware manufacturer %v not found", opts.FirmwareManufacturer)
 }
 
 func fromSevSnpAttestationProto(at *spb.Attestation) ([]byte, string, error) {
@@ -152,6 +149,10 @@ func fromSevSnpAttestationProto(at *spb.Attestation) ([]byte, string, error) {
 	}
 	meas := at.GetReport().GetMeasurement()
 	return nil, extractsev.GceTcbObjectName(sev.GCEUefiFamilyID, meas), nil
+}
+
+func fromTdxAttestationProto(at *tpb.QuoteV4) string {
+	return extracttdx.GCETcbObjectName(at.GetTdQuoteBody().GetMrTd())
 }
 
 // Attestation will try to deserialize a given attestation in any of the supported formats and
@@ -214,8 +215,9 @@ func (opts *Options) fromQuote(quote []byte) (endorsement []byte, objectName str
 	switch at := tpmat.TeeAttestation.(type) {
 	case *tpmpb.Attestation_SevSnpAttestation:
 		return fromSevSnpAttestationProto(at.SevSnpAttestation)
+	case *tpmpb.Attestation_TdxAttestation:
+		return nil, fromTdxAttestationProto(at.TdxAttestation), nil
 	}
-	// TODO: Otherwise try the TDX quote.
 	return nil, "", ErrUnknownFormat
 }
 
@@ -228,18 +230,18 @@ func Endorsement(opts *Options) (out []byte, err error) {
 	var quote, endorsement []byte
 	var objectName string
 	var evErr, quoteErr, internetErr error
-	// If the verbatim quote is provided, try that first.
-	endorsement, objectName, quoteErr = opts.fromQuote(opts.Quote)
-	if quoteErr == nil && len(endorsement) > 0 {
-		return endorsement, nil
-	}
-
-	// Then try the event logger.
+	// First try the event logger.
 	if opts.EventLogLocation != "" {
 		out, evErr = opts.fromEventLog()
 		if evErr == nil {
 			return out, nil
 		}
+	}
+
+	// If the verbatim quote is provided, try that next.
+	endorsement, objectName, quoteErr = opts.fromQuote(opts.Quote)
+	if quoteErr == nil && len(endorsement) > 0 {
+		return endorsement, nil
 	}
 
 	// Then try obtaining a quote for its auxblob or measurement if the objectName is not known.

--- a/extract/extractsev/extractsev.go
+++ b/extract/extractsev/extractsev.go
@@ -47,9 +47,9 @@ func gceTcbObjectPath(measurement []byte) string {
 	return fmt.Sprintf("sevsnp/%s.binarypb", hex.EncodeToString(measurement))
 }
 
-// GceTcbObjectName returns the expected object name within a GCS bucket for a firmware
+// GCETcbObjectName returns the expected object name within a GCS bucket for a firmware
 // measured for SEV-SNP.
-func GceTcbObjectName(familyID string, measurement []byte) string {
+func GCETcbObjectName(familyID string, measurement []byte) string {
 	return fmt.Sprintf("%s/%s", familyIDObjectPrefix(familyID), gceTcbObjectPath(measurement))
 }
 

--- a/extract/extractsev/extractsev_test.go
+++ b/extract/extractsev/extractsev_test.go
@@ -101,7 +101,7 @@ func TestFromCertTable(t *testing.T) {
 	}
 }
 
-func TestGceTcbObjectName(t *testing.T) {
+func TestGCETcbObjectName(t *testing.T) {
 	tcs := []struct {
 		name        string
 		familyID    string
@@ -129,9 +129,9 @@ func TestGceTcbObjectName(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GceTcbObjectName(tc.familyID, tc.measurement)
+			got := GCETcbObjectName(tc.familyID, tc.measurement)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
-				t.Fatalf("GceTcbObjectName(%v, %v) returned an unexpected diff (-got +want): %v",
+				t.Fatalf("GCETcbObjectName(%v, %v) returned an unexpected diff (-got +want): %v",
 					tc.familyID, tc.measurement, diff)
 			}
 		})

--- a/extract/extracttdx/extracttdx.go
+++ b/extract/extracttdx/extracttdx.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package extracttdx contains the implementation of the endorsement location derivation from MRTD.
+package extracttdx
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// gceTcbObjectPath returns the object path within the gce_tcb_integrity GCS bucket that
+// corresponds to the given SEV-SNP attestation report measurement.
+func gceTcbObjectPath(measurement []byte) string {
+	return fmt.Sprintf("tdx/%s.binarypb", hex.EncodeToString(measurement))
+}
+
+// GCETcbObjectName returns the expected object name within a GCS bucket for a firmware
+// measured for TDX.
+func GCETcbObjectName(measurement []byte) string {
+	return fmt.Sprintf("ovmf_x64_csm/%s", gceTcbObjectPath(measurement))
+}

--- a/gcetcbendorsement/sevvalidate.go
+++ b/gcetcbendorsement/sevvalidate.go
@@ -15,9 +15,9 @@
 package gcetcbendorsement
 
 import (
+	"context"
 	"crypto/x509"
 	"fmt"
-	"context"
 	"time"
 
 	"github.com/google/gce-tcb-verifier/extract/extractsev"
@@ -69,8 +69,8 @@ func extractEndorsement(attestation *spb.Attestation, opts *SevValidateOptions) 
 		return nil, fmt.Errorf("could not extract endorsement")
 
 	}
-	obj := extractsev.GceTcbObjectName(sev.GCEUefiFamilyID, attestation.GetReport().GetMeasurement())
-	url := verify.GceTcbURL(obj)
+	obj := extractsev.GCETcbObjectName(sev.GCEUefiFamilyID, attestation.GetReport().GetMeasurement())
+	url := verify.GCETcbURL(obj)
 	bin, err := opts.Getter.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get endorsement: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8
+	golang.org/x/text v0.14.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0
 )
@@ -28,7 +29,6 @@ require (
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect

--- a/ovmf/abi/abi.go
+++ b/ovmf/abi/abi.go
@@ -101,6 +101,9 @@ const (
 	SizeofTDXMetdataSection = 32
 	// TDXMetadataDescriptorMagic is the magic number for the TDXMetadataDescriptor Signature.
 	TDXMetadataDescriptorMagic = 0x46564454 // 'T', 'D', 'V', 'F'
+
+	// Tcg800155PlatformIDEventHobGUID is the GUID for the any SP800155 platform ID event HOB.
+	Tcg800155PlatformIDEventHobGUID = "e2c3bc69-615c-4b5b-8e5c-a033a9c25ed6"
 )
 
 // FwGUIDEntry is an ABI type found in OVMF binaries for describing a run of data in the binary as
@@ -172,6 +175,14 @@ func PutUUID(data []byte, guid uuid.UUID) error {
 	binary.LittleEndian.PutUint16(data[6:8], binary.BigEndian.Uint16(guid[6:8]))
 	copy(data[8:16], guid[8:16])
 	return nil
+}
+
+// FromUUID converts a uuid.UUID to EFIGUID.
+func FromUUID(guid uuid.UUID) EFIGUID {
+	var data [16]byte
+	PutUUID(data[:], guid)
+	result, _ := parseEFIGUID(data[:])
+	return result
 }
 
 // Put writes f in its ABI format to the beginning of data.

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -62,8 +62,8 @@ type HTTPSGetter interface {
 	Get(url string) ([]byte, error)
 }
 
-// GceTcbURL returns the URL to the named object within the gce-tcb-integrity storage bucket.
-func GceTcbURL(objectName string) string {
+// GCETcbURL returns the URL to the named object within the gce-tcb-integrity storage bucket.
+func GCETcbURL(objectName string) string {
 	return fmt.Sprintf("%s/gce_tcb_integrity/%s", gcsBaseURL, objectName)
 }
 
@@ -102,7 +102,7 @@ func SNPFamilyValidateFunc(familyID string, opts *Options) func(*spb.Attestation
 			if opts.Getter == nil {
 				return fmt.Errorf("endorsement getter is nil")
 			}
-			blob, err := opts.Getter.Get(GceTcbURL(extractsev.GceTcbObjectName(familyID, measurement)))
+			blob, err := opts.Getter.Get(GCETcbURL(extractsev.GCETcbObjectName(familyID, measurement)))
 			if err != nil {
 				return fmt.Errorf("could not fetch endorsement: %v", err)
 			}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -48,8 +48,8 @@ const gcsBaseURL = "https://storage.googleapis.com"
 // SNPOptions are SEV-SNP technology-specific validation options to check against the endorsement.
 type SNPOptions struct {
 	// measurement is an optional SEV-SNP measurement to check against the endorsement's list of
-	// measurements. It is not exported since it is only populated by a launch endorsement.
-	measurement []byte
+	// measurements.
+	Measurement []byte
 	// ExpectedLaunchVMSAs is an optional (0 ignored) number of expected VMSAs to have launched with.
 	// The effect is that the measurement is compared against only the measurement computed for this
 	// VMSA count. It is an error for ExpectedLaunchVMSAs to be non-zero while Measurement is nil.
@@ -109,7 +109,7 @@ func SNPFamilyValidateFunc(familyID string, opts *Options) func(*spb.Attestation
 			serializedEndorsement = blob
 
 		}
-		opts.SNP.measurement = measurement
+		opts.SNP.Measurement = measurement
 		return Endorsement(serializedEndorsement, opts)
 	}
 }
@@ -182,22 +182,22 @@ func SNP(golden *epb.VMGoldenMeasurement, opts *SNPOptions) error {
 		if !ok {
 			return fmt.Errorf("no golden measurement for %d launch VMSAs", opts.ExpectedLaunchVMSAs)
 		}
-		if !bytes.Equal(measure, opts.measurement) {
+		if !bytes.Equal(measure, opts.Measurement) {
 			return fmt.Errorf("given measure %s does not match measurement for %d VMSAs %s",
-				hex.EncodeToString(measure), opts.ExpectedLaunchVMSAs, hex.EncodeToString(opts.measurement))
+				hex.EncodeToString(measure), opts.ExpectedLaunchVMSAs, hex.EncodeToString(opts.Measurement))
 		}
-	} else if opts.measurement != nil {
+	} else if opts.Measurement != nil {
 		// Check the measurement against any of the launch VMSA measurements.
 		var found bool
 		for _, measure := range snp.Measurements {
-			if bytes.Equal(measure, opts.measurement) {
+			if bytes.Equal(measure, opts.Measurement) {
 				found = true
 				break
 			}
 		}
 		if !found {
 			return fmt.Errorf("measure %s does not match any golden measurement",
-				hex.EncodeToString(opts.measurement))
+				hex.EncodeToString(opts.Measurement))
 		}
 	}
 	return nil


### PR DESCRIPTION
This produces another file alongside the snapshotted firmware and signature for the VMM to provide as a boot-services UEFI variable. The firmware will read this and extend the HOB list in the PEI stage to make Tcg2Dxe emit the EV_NO_ACTION events for verifiers to read and find where the reference values can be found.

Changes to existing marshaling logic comes from debugging an end-to-end test.