### PR TITLE
Fix HOB length bounds and TDX extraction

### DIFF
--- a/endorse/sp800155_test.go
+++ b/endorse/sp800155_test.go
@@ -64,7 +64,8 @@ func TestMakeEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("makeEvents(%v) failed: %v", e, err)
 	}
-	varEvt := combine([]byte{0x92, 0, 0, 0}, []byte("SP800-155 Event3"),
+	varEvt := combine([]byte{0x92, 0x00}, // Event length as little endian uint16
+		[]byte("SP800-155 Event3"),
 		binary.LittleEndian.AppendUint32(nil, 11129), // PlatformManufacturerID
 		rimEFIGUID, // ReferenceManifestGuid
 		append([]byte{byte(len(googleManufacturer))}, []byte(googleManufacturer)...), // PlatformManufacturerStr
@@ -79,13 +80,15 @@ func TestMakeEvents(t *testing.T) {
 		[]byte{0, 0, 0, 0}, // Platform cert locator type
 		[]byte{0, 0, 0, 0}, // Platform cert length
 	)
-	if len(varEvt) != 150 {
-		t.Errorf("varEvt = %v (size %d), want length 150", varEvt, len(varEvt))
+	wantVarLen := 148
+	if len(varEvt) != wantVarLen {
+		t.Errorf("varEvt = %v, want length %d", varEvt, wantVarLen)
 	}
-	if diff := cmp.Diff(varEvt, blob[:150]); diff != "" {
-		t.Errorf("makeEvents(%v) = %v..., want %v...: diff (-want, +got) %s", e, blob[:150], varEvt, diff)
+	if diff := cmp.Diff(varEvt, blob[:wantVarLen]); diff != "" {
+		t.Errorf("makeEvents(%v) = %v..., want %v...: diff (-want, +got) %s", e, blob[:wantVarLen], varEvt, diff)
 	}
-	if len(blob) != 428 {
-		t.Errorf("makeEvents(%v) = %v, want length 428", e, len(blob))
+	wantBlobLen := 276 + wantVarLen
+	if len(blob) != wantBlobLen {
+		t.Errorf("makeEvents(%v) = %v, want length %d", e, len(blob), wantBlobLen)
 	}
 }

--- a/eventlog/tcg2.go
+++ b/eventlog/tcg2.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+
+	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
 )
 
 const (
@@ -148,5 +150,9 @@ func (evt *SP800155Event3) MarshalToBytes() ([]byte, error) {
 	if err := littleWrite(w, "PlatformCertLocator", &evt.PlatformCertLocator); err != nil {
 		return nil, err
 	}
-	return w.Bytes(), nil
+	result := w.Bytes()
+	if len(result) > oabi.MaxGUIDHOBDataSize {
+		return nil, fmt.Errorf("event is too large for an EFI_HOB_GUID_TYPE: %d bytes", len(result))
+	}
+	return result, nil
 }

--- a/extract/configfs.go
+++ b/extract/configfs.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extract
+
+import (
+	"fmt"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+	"github.com/google/go-configfs-tsm/configfs/linuxtsm"
+	"github.com/google/go-configfs-tsm/report"
+)
+
+// ConfigfsTsmQuoteProvider provides quotes through the Linux configfs-tsm report interface.
+type ConfigfsTsmQuoteProvider struct {
+	Client configfsi.Client
+}
+
+// IsSupported returns true if the quote provider supports configfs-tsm reports.
+func (qp *ConfigfsTsmQuoteProvider) IsSupported() bool {
+	if qp.Client != nil {
+		return true
+	}
+	cl, err := linuxtsm.MakeClient()
+	qp.Client = cl
+	return err == nil
+}
+
+// GetRawQuote returns the raw quote from the configfs-tsm report.
+func (qp *ConfigfsTsmQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
+	if qp.Client == nil {
+		cl, err := linuxtsm.MakeClient()
+		if err != nil {
+			return nil, fmt.Errorf("quote provider used outside IsSupported guard: %v", err)
+		}
+		qp.Client = cl
+	}
+
+	resp, err := report.Get(qp.Client, &report.Request{InBlob: reportData[:]})
+	if err != nil {
+		return nil, err
+	}
+	return resp.OutBlob, nil
+}

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -59,7 +59,7 @@ var (
 const (
 	// GCEFirmwareManufacturer is the expected FirmwareManufacturer value in an SP800-155 Event3 event
 	// on a GCE VM.
-	GCEFirmwareManufacturer = "GCE"
+	GCEFirmwareManufacturer = "Google, Inc."
 )
 
 // QuoteProvider provides a raw quote within a trusted execution environment.

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/go-sev-guest/abi"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/google/go-sev-guest/verify/trust"
+	tabi "github.com/google/go-tdx-guest/abi"
 	tpb "github.com/google/go-tdx-guest/proto/tdx"
 	tpmpb "github.com/google/go-tpm-tools/proto/attest"
 	"go.uber.org/multierr"
@@ -180,7 +181,11 @@ func Attestation(quote []byte) (*tpmpb.Attestation, error) {
 		return tpmat, nil
 	}
 
-	// TODO: Try the TDX quote proto.
+	tdx := &tpb.QuoteV4{}
+	if err := proto.Unmarshal(quote, tdx); err == nil {
+		tpmat.TeeAttestation = &tpmpb.Attestation_TdxAttestation{TdxAttestation: tdx}
+		return tpmat, nil
+	}
 
 	// If hex- or base64-encoded, decode it.
 	if decoded, err := hex.DecodeString(string(quote)); err == nil {
@@ -202,6 +207,17 @@ func Attestation(quote []byte) (*tpmpb.Attestation, error) {
 		sev.CertificateChain = certs.Proto()
 		tpmat.TeeAttestation = &tpmpb.Attestation_SevSnpAttestation{SevSnpAttestation: sev}
 		return tpmat, nil
+	}
+
+	// Attempt to decode as a raw TDX quote.
+	if tdxquote, err := tabi.QuoteToProto(quote); err == nil {
+		switch tq := tdxquote.(type) {
+		case *tpb.QuoteV4:
+			tpmat.TeeAttestation = &tpmpb.Attestation_TdxAttestation{TdxAttestation: tq}
+			return tpmat, nil
+		default:
+			return nil, fmt.Errorf("unknown TDX attestation format %T", tdxquote)
+		}
 	}
 	return nil, ErrUnknownFormat
 }

--- a/gcetcbendorsement/cmd/extract.go
+++ b/gcetcbendorsement/cmd/extract.go
@@ -109,7 +109,7 @@ If PATH is provided it must be to an attestation in one of the following formats
 	cmd.Flags().StringVar(&e.output, "out", "endorsement.binarypb",
 		"The output destination for the extracted endorsement. Default endorsement.binarypb")
 	cmd.Flags().StringVar(&e.eventlogpath, "eventlog", "/sys/kernel/security/tpm0/binary_bios_measurements", "The path to the bios boot event log")
-	cmd.Flags().StringVar(&e.manufacturer, "firmware_manufacturer", "Google, Inc.", "The firmware manufacturer string to search for in SP800155 events.")
+	cmd.Flags().StringVar(&e.manufacturer, "firmware_manufacturer", extract.GCEFirmwareManufacturer, "The firmware manufacturer string to search for in SP800155 events.")
 	cmd.Flags().StringVar(&e.efivarloc, "efivarfs", "/sys/firmware/efi/efivars", "The efivarfs mount location.")
 	cmd.SetContext(ctx)
 	return cmd

--- a/gcetcbendorsement/cmd/root.go
+++ b/gcetcbendorsement/cmd/root.go
@@ -23,9 +23,7 @@ import (
 	"github.com/google/gce-tcb-verifier/extract"
 	exel "github.com/google/gce-tcb-verifier/extract/eventlog"
 	"github.com/google/gce-tcb-verifier/verify"
-	"github.com/google/go-sev-guest/client"
 	"github.com/google/go-sev-guest/verify/trust"
-	"github.com/google/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -72,12 +70,8 @@ func MakeRoot(ctx0 context.Context) *cobra.Command {
 }
 
 func init() {
-	qp, err := client.GetQuoteProvider()
-	if err != nil {
-		logger.Fatal(err)
-	}
 	RootCmd = MakeRoot(context.WithValue(context.Background(), backendKey, &Backend{
-		Provider: qp,
+		Provider: &extract.ConfigfsTsmQuoteProvider{},
 		Getter:   trust.DefaultHTTPSGetter(),
 		MakeEfiVariableReader: func(path string) exel.VariableReader {
 			return exel.MakeEfiVarFSReader(path)

--- a/ovmf/abi/pihob.go
+++ b/ovmf/abi/pihob.go
@@ -32,7 +32,7 @@ const (
 	// SizeofHOBGUID is the size of the GUID HOB header prior to associated data.
 	SizeofHOBGUID = SizeofHOBGenericHeader + 16
 	// MaxGUIDHOBDataSize is the maximum size of an EFI_HOB_GUID_TYPE's associated data.
-	MaxGUIDHOBDataSize = 0x1000 - SizeofHOBGUID
+	MaxGUIDHOBDataSize = 0x10000 - SizeofHOBGUID
 )
 
 // EFIResourceType is an enum type for resource descriptors.


### PR DESCRIPTION
The SP800155 events fit in a single page, but the technical limit is UINT16. I've added a check at marshaling time too, so too-large events don't make it past signing.

The SEV-SNP client in the extraction CLI command needed to get swapped with the more general configfs-tsm client to account for TDX. We still should not expect to need the query provider if the signatures are provided through the event log, but better to cover our bases.