### PR TITLE
Fix a bad default

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -86,9 +86,7 @@ func SNPValidateFunc(opts *Options) func(*spb.Attestation, []byte) error {
 // SEV-SNP attestation report given an expected familyID.
 func SNPFamilyValidateFunc(familyID string, opts *Options) func(*spb.Attestation, []byte) error {
 	if opts.SNP == nil {
-		return func(*spb.Attestation, []byte) error {
-			return nil
-		}
+		opts.SNP = &SNPOptions{}
 	}
 	return func(attestation *spb.Attestation, serializedEndorsement []byte) error {
 		if attestation == nil {


### PR DESCRIPTION
When SNPOptions is nil, the SNPValidateFunc will always succeed. The function is explicitly requesting SNP validation, so it should instead treat the SNP option as a default &SNPOptions{} to fail when it should correctly fail.

Found when integrating with go-tpm-tools and didn't provide `&SNPOptions{}`