### PR TITLE
Allow wiping just certs or keys

### DIFF
--- a/keys/gcpkms/bootstrap_test.go
+++ b/keys/gcpkms/bootstrap_test.go
@@ -630,7 +630,7 @@ func TestWipeoutAfterBootstrap(t *testing.T) {
 		rootVersion2: {Name: rootVersion2, State: kmspb.CryptoKeyVersion_DESTROY_SCHEDULED},
 		rootVersion3: {Name: rootVersion3, State: kmspb.CryptoKeyVersion_DESTROYED},
 	}
-	if err := rotate.Wipeout(b.ctx); err != nil {
+	if err := rotate.Wipeout(rotate.NewWipeoutContext(b.ctx, &rotate.WipeoutContext{CA: true, Keys: true})); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := b.ca.Storage.Reader(b.ctx, "test", gcsca.ManifestObjectName); err == nil || !os.IsNotExist(err) {

--- a/testing/nonprod/localkm/localkm_test.go
+++ b/testing/nonprod/localkm/localkm_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/gce-tcb-verifier/cmd"
 	"github.com/google/gce-tcb-verifier/keys"
+	"github.com/google/gce-tcb-verifier/rotate"
 	"github.com/google/gce-tcb-verifier/sign/memca"
 	"github.com/google/gce-tcb-verifier/sign/nonprod"
 	"github.com/google/gce-tcb-verifier/testing/devkeys"
@@ -85,10 +86,11 @@ func TestWipeout(t *testing.T) {
 	ctx0 := context.Background()
 	keyDir := t.TempDir()
 	m, ctx1 := readyManager(ctx0, t, []string{"--key_dir", keyDir})
-	ctx, err := cmd.ComposeInitContext(ctx1, m, memca.Create())
+	ctx2, err := cmd.ComposeInitContext(ctx1, m, memca.Create())
 	if err != nil {
 		t.Fatalf("ComposeInitContext(_, %v, memca) = %v, want nil", m, err)
 	}
+	ctx := rotate.NewWipeoutContext(ctx2, &rotate.WipeoutContext{CA: true, Keys: true})
 	testkm.Wipeout(ctx, t)
 	if _, err := os.Stat(path.Join(keyDir, "root.pem")); err == nil {
 		t.Fatalf("localkm Wipeout() did not delete root.pem")

--- a/testing/nonprod/memkm/memkm_test.go
+++ b/testing/nonprod/memkm/memkm_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/gce-tcb-verifier/cmd"
 	"github.com/google/gce-tcb-verifier/keys"
+	"github.com/google/gce-tcb-verifier/rotate"
 	"github.com/google/gce-tcb-verifier/sign/memca"
 	"github.com/google/gce-tcb-verifier/sign/nonprod"
 	"github.com/google/gce-tcb-verifier/testing/testkm"
@@ -104,7 +105,9 @@ func TestNonprodWipeout(t *testing.T) {
 	ca := memca.Create()
 	c := &cobra.Command{}
 	ctx0 := context.Background()
-	c.SetContext(keys.NewContext(ctx0, &keys.Context{Random: testsign.SignerRand()}))
+	c.SetContext(rotate.NewWipeoutContext(
+		keys.NewContext(ctx0, &keys.Context{Random: testsign.SignerRand()}),
+		&rotate.WipeoutContext{CA: true, Keys: true}))
 	m.AddFlags(c)
 	ca.AddFlags(c)
 

--- a/testing/testkms/fake_kms_test.go
+++ b/testing/testkms/fake_kms_test.go
@@ -101,10 +101,11 @@ func TestFakeKms(t *testing.T) {
 	})
 	rotatedKeyVersionName := m.FullKeyName("test-signing-key") + "/cryptoKeyVersions/2"
 	testkm.Rotate(rctx, t, rotatedKeyVersionName)
-	if err := rotate.Wipeout(ctx1); err != nil {
+	ctx2 := rotate.NewWipeoutContext(ctx1, &rotate.WipeoutContext{CA: true, Keys: true})
+	if err := rotate.Wipeout(ctx2); err != nil {
 		t.Errorf("rotate.Wipeout() = %v, want nil", err)
 	}
-	testkm.PostWipeoutProperties(ctx1, t, &testkm.Options{
+	testkm.PostWipeoutProperties(ctx2, t, &testkm.Options{
 		RootKeyVersionName:           m.FullKeyName("test-root-key") + "/cryptoKeyVersions/1",
 		PrimarySigningKeyVersionName: rotatedKeyVersionName,
 	})


### PR DESCRIPTION
When cleaning up our e2e test environment ahead of running the test, only stale certs may be left behind since the keyring is randomly named.