### PR TITLE
Fix ByteSizeArray to CStr and drop uint16 size

### DIFF
--- a/endorse/sp800155.go
+++ b/endorse/sp800155.go
@@ -15,7 +15,6 @@
 package endorse
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -33,6 +32,8 @@ const (
 	googleID           = 11129          // IANA PEN
 	googleManufacturer = "Google, Inc." // IANA PEN text
 	platformModel      = "Google Compute Engine"
+	platformVersion    = ""    // Unknown
+	firmwareVersion    = "2.7" // EFI_SYSTEM_TABLE_REVISION
 )
 
 var (
@@ -47,18 +48,15 @@ func googleSp800155Event(rimGUID eventlog.EfiGUID, locType uint32, loc []byte) *
 	return &eventlog.SP800155Event3{
 		PlatformManufacturerID:  11129,
 		ReferenceManifestGUID:   rimGUID,
-		PlatformManufacturerStr: eventlog.ByteSizedArray{Data: []byte(googleManufacturer)},
-		PlatformModel:           eventlog.ByteSizedArray{Data: []byte(platformModel)},
-		FirmwareManufacturerStr: eventlog.ByteSizedArray{Data: []byte(googleManufacturer)},
+		PlatformManufacturerStr: eventlog.ByteSizedCStr{Data: googleManufacturer},
+		PlatformModel:           eventlog.ByteSizedCStr{Data: platformModel},
+		PlatformVersion:         eventlog.ByteSizedCStr{Data: platformVersion},
+		FirmwareManufacturerStr: eventlog.ByteSizedCStr{Data: googleManufacturer},
 		FirmwareManufacturerID:  11129,
+		FirmwareVersion:         eventlog.ByteSizedCStr{Data: firmwareVersion},
 		RIMLocatorType:          locType,
 		RIMLocator:              eventlog.Uint32SizedArray{Data: loc},
 	}
-}
-
-// An SP800155 event is stored in a HOB, which has a maximum size of UINT16 bytes including headers.
-func marshalUint16Str(data []byte) []byte {
-	return append(binary.LittleEndian.AppendUint16(nil, uint16(len(data))), data...)
 }
 
 func varEvent(rimGUID eventlog.EfiGUID) ([]byte, error) {
@@ -66,7 +64,7 @@ func varEvent(rimGUID eventlog.EfiGUID) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal UEFI variable SP800155 event: %v", err)
 	}
-	return marshalUint16Str(result), nil
+	return result, nil
 }
 
 func uriEvent(rimGUID eventlog.EfiGUID, digest []byte) ([]byte, error) {
@@ -78,7 +76,7 @@ func uriEvent(rimGUID eventlog.EfiGUID, digest []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal URI SP800155 event: %v", err)
 	}
-	return marshalUint16Str(result), nil
+	return result, nil
 }
 
 // makeEvents returns the boot service UEFI variable contents the firmware will use to populate the

--- a/endorse/sp800155_test.go
+++ b/endorse/sp800155_test.go
@@ -64,30 +64,29 @@ func TestMakeEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("makeEvents(%v) failed: %v", e, err)
 	}
-	varEvt := combine([]byte{0x92, 0x00}, // Event length as little endian uint16
-		[]byte("SP800-155 Event3"),
+	varEvt := combine([]byte("SP800-155 Event3"),
 		binary.LittleEndian.AppendUint32(nil, 11129), // PlatformManufacturerID
 		rimEFIGUID, // ReferenceManifestGuid
-		append([]byte{byte(len(googleManufacturer))}, []byte(googleManufacturer)...), // PlatformManufacturerStr
-		append([]byte{byte(len(platformModel))}, []byte(platformModel)...),           // PlatformModel
-		[]byte{0}, // PlatformVersion
-		append([]byte{byte(len(googleManufacturer))}, []byte(googleManufacturer)...), // FirmwareManufacturerStr
-		binary.LittleEndian.AppendUint32(nil, 11129),                                 // FirmwareManufacturerID
-		[]byte{0}, // FirmwareVersion
-		binary.LittleEndian.AppendUint32(nil, eventlog.RIMLocationVariable), // RIM locator type
-		binary.LittleEndian.AppendUint32(nil, uint32(len(rimVar))),          // RIM locator (length)
+		append([]byte{byte(len(googleManufacturer) + 1)}, []byte(googleManufacturer+"\x00")...), // PlatformManufacturerStr
+		append([]byte{byte(len(platformModel) + 1)}, []byte(platformModel+"\x00")...),           // PlatformModel
+		[]byte{1, 0}, // PlatformVersion
+		append([]byte{byte(len(googleManufacturer) + 1)}, []byte(googleManufacturer+"\x00")...), // FirmwareManufacturerStr
+		binary.LittleEndian.AppendUint32(nil, 11129),                                            // FirmwareManufacturerID
+		append([]byte{byte(len(firmwareVersion)) + 1}, []byte(firmwareVersion+"\x00")...),       // FirmwareVersion
+		binary.LittleEndian.AppendUint32(nil, eventlog.RIMLocationVariable),                     // RIM locator type
+		binary.LittleEndian.AppendUint32(nil, uint32(len(rimVar))),                              // RIM locator (length)
 		rimVar,             // Rim locator (data)
 		[]byte{0, 0, 0, 0}, // Platform cert locator type
 		[]byte{0, 0, 0, 0}, // Platform cert length
 	)
-	wantVarLen := 148
+	wantVarLen := 154
 	if len(varEvt) != wantVarLen {
 		t.Errorf("varEvt = %v, want length %d", varEvt, wantVarLen)
 	}
 	if diff := cmp.Diff(varEvt, blob[:wantVarLen]); diff != "" {
 		t.Errorf("makeEvents(%v) = %v..., want %v...: diff (-want, +got) %s", e, blob[:wantVarLen], varEvt, diff)
 	}
-	wantBlobLen := 276 + wantVarLen
+	wantBlobLen := 282 + wantVarLen
 	if len(blob) != wantBlobLen {
 		t.Errorf("makeEvents(%v) = %v, want length %d", e, len(blob), wantBlobLen)
 	}

--- a/eventlog/marshal.go
+++ b/eventlog/marshal.go
@@ -29,9 +29,13 @@ type Marshallable interface {
 
 // Marshal writes an array of bytes no longer than 255 entries with an initial byte noting
 // the array length, and then each byte of the array afterwards.
-func (b *ByteSizedArray) Marshal(w io.Writer) error {
-	size := byte(len(b.Data))
-	return writeSizedArray(w, size, b.Data)
+func (b *ByteSizedCStr) Marshal(w io.Writer) error {
+	data := []byte(b.Data + "\x00")
+	if len(data) > 255 {
+		return fmt.Errorf("data is too long for ByteSizedCStr: %d", len(data))
+	}
+	size := byte(len(data))
+	return writeSizedArray(w, size, data)
 }
 
 // Marshal writes an array of bytes with a initial 4 bytes in little endian noting

--- a/eventlog/tcg2.go
+++ b/eventlog/tcg2.go
@@ -49,12 +49,12 @@ var (
 type SP800155Event3 struct {
 	PlatformManufacturerID  uint32
 	ReferenceManifestGUID   EfiGUID
-	PlatformManufacturerStr ByteSizedArray
-	PlatformModel           ByteSizedArray
-	PlatformVersion         ByteSizedArray
-	FirmwareManufacturerStr ByteSizedArray
+	PlatformManufacturerStr ByteSizedCStr
+	PlatformModel           ByteSizedCStr
+	PlatformVersion         ByteSizedCStr
+	FirmwareManufacturerStr ByteSizedCStr
 	FirmwareManufacturerID  uint32
-	FirmwareVersion         ByteSizedArray
+	FirmwareVersion         ByteSizedCStr
 	RIMLocatorType          uint32
 	RIMLocator              Uint32SizedArray
 	PlatformCertLocatorType uint32

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -75,7 +75,7 @@ type QuoteProvider interface {
 type Options struct {
 	Provider             QuoteProvider
 	Getter               trust.HTTPSGetter
-	FirmwareManufacturer []byte
+	FirmwareManufacturer string
 	EventLogLocation     string
 	UEFIVariableReader   exel.VariableReader
 	// Quote is any of the supported formats. If empty, the Provider will be used to get a quote.
@@ -88,7 +88,7 @@ func DefaultOptions() *Options {
 	return &Options{
 		// Provider:             &client.TEEQuoteProvider{},
 		Getter:               lopts.Getter,
-		FirmwareManufacturer: []byte(GCEFirmwareManufacturer),
+		FirmwareManufacturer: GCEFirmwareManufacturer,
 		EventLogLocation:     "/sys/kernel/security/tpm0/binary_bios_measurements",
 		UEFIVariableReader:   lopts.UEFIVariableReader,
 		Quote:                []byte{},
@@ -136,7 +136,7 @@ func (opts *Options) fromEventLog() ([]byte, error) {
 		// Finally reach out to the network.
 		evts[eventlog.RIMLocationURI]} {
 		for _, evt := range evts {
-			if len(opts.FirmwareManufacturer) == 0 || bytes.Equal(evt.FirmwareManufacturerStr.Data, opts.FirmwareManufacturer) {
+			if len(opts.FirmwareManufacturer) == 0 || evt.FirmwareManufacturerStr.Data == opts.FirmwareManufacturer {
 				return exel.Locate(evt.RIMLocatorType, evt.RIMLocator.Data, locopts)
 			}
 		}

--- a/extract/extract_test.go
+++ b/extract/extract_test.go
@@ -179,7 +179,7 @@ func TestExtractEndorsement(t *testing.T) {
 					Events: []*eventlog.TCGPCREvent2{
 						{EventType: eventlog.EvNoAction,
 							EventData: eventlog.TCGEventData{Event: &eventlog.SP800155Event3{
-								FirmwareManufacturerStr: eventlog.ByteSizedArray{Data: []byte(GCEFirmwareManufacturer)},
+								FirmwareManufacturerStr: eventlog.ByteSizedCStr{Data: GCEFirmwareManufacturer},
 								RIMLocatorType:          eventlog.RIMLocationVariable,
 								RIMLocator:              eventlog.Uint32SizedArray{Data: append(myEfiGUID, 'V', 0, 'a', 0, 'r', 0, 0, 0)},
 							}}},
@@ -189,7 +189,7 @@ func TestExtractEndorsement(t *testing.T) {
 
 				return &Options{
 					EventLogLocation:     evlog,
-					FirmwareManufacturer: []byte(GCEFirmwareManufacturer),
+					FirmwareManufacturer: GCEFirmwareManufacturer,
 					UEFIVariableReader:   exel.MakeEfiVarFSReader(efidir),
 				}
 			}(),

--- a/gcetcbendorsement/cmd/extract.go
+++ b/gcetcbendorsement/cmd/extract.go
@@ -79,7 +79,7 @@ func (c *extractCommand) runE(cmd *cobra.Command, args []string) error {
 	endorsement, err := extract.Endorsement(&extract.Options{
 		Provider:             backend.Provider,
 		Getter:               backend.Getter,
-		FirmwareManufacturer: []byte(c.manufacturer),
+		FirmwareManufacturer: c.manufacturer,
 		EventLogLocation:     c.eventlogpath,
 		UEFIVariableReader:   reader,
 		Quote:                c.content,


### PR DESCRIPTION
Upstream doesn't like the UINT16 event size prefix to make ingestion easier, so now the ~700 line parser is in review for EDK2.

The Byte strings are all expected to be 0-terminated C strings, so I've added that to the marshaling and unmarshaling logic. It's unclear if a size 0 string is allowed since the string is expected to be null-terminated, so I've gone with expecting to emit a null for empty string.