### PR TITLE
Change ovmfsev to fakeovmf and add TDVF metadata

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/google/gce-tcb-verifier/endorse"
 	"github.com/google/gce-tcb-verifier/keys"
 	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/match"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/spf13/cobra"
 )
 
@@ -252,8 +252,8 @@ func TestSevSnpMeasurementOnly(t *testing.T) {
 	var firmware [0x1000]byte
 	copy(firmware[0x800:], []byte("LGTMLGTMLGTMLGTM"))
 	copy(firmware[0xa00:], []byte("LGTMLGTMLGTMLGTM"))
-	if err := ovmfsev.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, ovmfsev.SevEsAddrVal, ovmfsev.DefaultSnpSections()); err != nil {
-		t.Fatalf("ovmfsev.InitializeSevGUIDTable() errored unexpectedly: %v", err)
+	if err := fakeovmf.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, fakeovmf.SevEsAddrVal, fakeovmf.DefaultSnpSections()); err != nil {
+		t.Fatalf("fakeovmf.InitializeSevGUIDTable() errored unexpectedly: %v", err)
 	}
 	c.SetContext(keys.NewContext(context.Background(), &keys.Context{}))
 	cmp.AddFlags(c)

--- a/gcetcbendorsement/sevvalidate_test.go
+++ b/gcetcbendorsement/sevvalidate_test.go
@@ -15,10 +15,10 @@
 package gcetcbendorsement
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
-	"context"
 	"os"
 	"path"
 	"testing"
@@ -28,10 +28,10 @@ import (
 	"github.com/google/gce-tcb-verifier/keys"
 	"github.com/google/gce-tcb-verifier/sev"
 	"github.com/google/gce-tcb-verifier/sign/memca"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/match"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/localnonvcs"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/memkm"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/google/gce-tcb-verifier/testing/testsign"
 	"github.com/google/go-sev-guest/abi"
 	cpb "github.com/google/go-sev-guest/proto/check"
@@ -54,7 +54,7 @@ func TestSevValidate(t *testing.T) {
 			Product:     spb.SevProduct_SEV_PRODUCT_MILAN,
 		},
 		ClSpec:    4321,
-		Image:     ovmfsev.CleanExample(t, 2*1024*1024),
+		Image:     fakeovmf.CleanExample(t, 2*1024*1024),
 		VCS:       &localnonvcs.T{Root: dir},
 		Timestamp: now,
 	}
@@ -89,7 +89,7 @@ func TestSevValidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("test.DefaultTestOnlyCertChain() = %v, want nil", err)
 	}
-	cleanMeasurement := "2247cc90eae3eff72c8d4b4ea5fefb8914bd80ad093859d5d022332eba7c7abe59e13d525c941ede5541191d7149585d"
+	cleanMeasurement := "20ec0dbd1c0a26d184a6f11ec5a796d68ec03c9d101bdd84c03f3d9cbbc4a292a9fad098edacfa04da0da58f20be885e"
 	meas, _ := hex.DecodeString(cleanMeasurement)
 	endorsementURI := fmt.Sprintf("https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/%s.binarypb", cleanMeasurement)
 	report := &spb.Report{

--- a/ovmf/sev_data.go
+++ b/ovmf/sev_data.go
@@ -88,12 +88,12 @@ func SevSectionTypeToString(kind uint32) string {
 // if present.
 func extractSevOvmfMetadata(guidBlockMap map[string][]byte, firmware []byte) ([]abi.SevMetadataSection, error) {
 	// Extract the GUID table from the firmware.
-	guidBlock, err := extractGUIDBlockFromMap(guidBlockMap, abi.SevMetadataOffsetGUID, abi.SizeofSevMetadataOffset)
+	guidBlock, err := extractGUIDBlockFromMap(guidBlockMap, abi.SevMetadataOffsetGUID, abi.SizeofMetadataOffset)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract SEV metadata offset GUID block: %v", err)
 	}
 
-	metadataOffset, err := abi.SevMetadataOffsetFromBytes(guidBlock)
+	metadataOffset, err := abi.MetadataOffsetFromBytes(guidBlock)
 	if err != nil {
 		return nil, fmt.Errorf("could not extract SEV metadata offset: %v", err)
 	}

--- a/sev/sev_test.go
+++ b/sev/sev_test.go
@@ -22,8 +22,8 @@ import (
 	oabi "github.com/google/gce-tcb-verifier/ovmf/abi"
 	epb "github.com/google/gce-tcb-verifier/proto/endorsement"
 	spb "github.com/google/gce-tcb-verifier/proto/sev"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/match"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/google/go-cmp/cmp"
 	sgpb "github.com/google/go-sev-guest/proto/sevsnp"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -859,15 +859,15 @@ func TestLaunchDigest(t *testing.T) {
 	// print(', '.join([hex(b) for b in digest_cur]))
 	// ```
 	// </code>
-	firmware := ovmfsev.CleanExample(t, 0x1000)
+	firmware := fakeovmf.CleanExample(t, 0x1000)
 	digest, err := LaunchDigest(&LaunchOptions{Vcpus: 1, Product: sgpb.SevProduct_SEV_PRODUCT_MILAN}, firmware[:])
 	if err != nil {
 		t.Fatalf("LaunchDigest(&LaunchOptions{Vcpus: 1, Product: Milan}, firmware[:]) errored unexpectedly: %v", err)
 	}
 	want := []byte{
-		0x6, 0x84, 0x3d, 0xe0, 0xc, 0x62, 0xbb, 0x9a, 0x12, 0xfd, 0x87, 0xb, 0xd3, 0x40, 0xe1, 0xaf,
-		0x8b, 0xe, 0xbf, 0x51, 0x6e, 0x3f, 0xe0, 0x4f, 0x5c, 0x9a, 0xdd, 0x43, 0xb7, 0x98, 0x1a, 0x1d,
-		0xf2, 0xe8, 0x25, 0xb4, 0xc7, 0x12, 0xfb, 0xd8, 0x7c, 0x97, 0xb1, 0x29, 0xeb, 0xa2, 0xe6, 0xde}
+		0x30, 0x1a, 0x56, 0xe0, 0x01, 0x40, 0x65, 0xed, 0x60, 0xa3, 0xc8, 0x48, 0xea, 0x0d, 0x3d, 0x0b,
+		0x2a, 0xa4, 0x6f, 0x4b, 0xfe, 0xa9, 0xdd, 0xea, 0xdb, 0xc6, 0x02, 0x14, 0x6d, 0x4c, 0x08, 0x78,
+		0x51, 0xab, 0x2c, 0x15, 0xd5, 0x73, 0xf8, 0xb2, 0xa4, 0x2e, 0xcc, 0x82, 0xd7, 0x4c, 0x9d, 0xb8}
 	if !bytes.Equal(digest, want) {
 		t.Errorf("LaunchDigest(&LaunchOptions{Vcpus: 1, Product: Milan}, firmware[:]) = %v, want %v", digest, want)
 	}
@@ -877,8 +877,8 @@ func TestUnsignedSnp(t *testing.T) {
 	var firmware [0x1000]byte
 	copy(firmware[0x800:], []byte("LGTMLGTMLGTMLGTM"))
 	copy(firmware[0xa00:], []byte("LGTMLGTMLGTMLGTM"))
-	if err := ovmfsev.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, ovmfsev.SevEsAddrVal, ovmfsev.DefaultSnpSections()); err != nil {
-		t.Fatalf("ovmfsev.InitializeSevGUIDTable() errored unexpectedly: %v", err)
+	if err := fakeovmf.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, fakeovmf.SevEsAddrVal, fakeovmf.DefaultSnpSections()); err != nil {
+		t.Fatalf("fakeovmf.InitializeSevGUIDTable() errored unexpectedly: %v", err)
 	}
 
 	snpRequest := &SnpEndorsementRequest{
@@ -911,8 +911,8 @@ func TestAllVmsas(t *testing.T) {
 	var firmware [0x1000]byte
 	copy(firmware[0x800:], []byte("LGTMLGTMLGTMLGTM"))
 	copy(firmware[0xa00:], []byte("LGTMLGTMLGTMLGTM"))
-	if err := ovmfsev.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, ovmfsev.SevEsAddrVal, ovmfsev.DefaultSnpSections()); err != nil {
-		t.Fatalf("ovmfsev.InitializeSevGUIDTable() errored unexpectedly: %v", err)
+	if err := fakeovmf.InitializeSevGUIDTable(firmware[:], oabi.FwGUIDTableEndOffset, fakeovmf.SevEsAddrVal, fakeovmf.DefaultSnpSections()); err != nil {
+		t.Fatalf("fakeovmf.InitializeSevGUIDTable() errored unexpectedly: %v", err)
 	}
 
 	snpRequest := &SnpEndorsementRequest{Product: sgpb.SevProduct_SEV_PRODUCT_MILAN}

--- a/testing/fakeovmf/fake_fw.go
+++ b/testing/fakeovmf/fake_fw.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakeovmf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/gce-tcb-verifier/ovmf/abi"
+	"github.com/google/uuid"
+)
+
+// InitializeGUIDTable initializes the GUID table with the given block sizes and populateFns.
+func InitializeGUIDTable(
+	firmware []byte,
+	baseOffsetFromEnd int,
+	blockSizes []uint16,
+	populateFns []func(offset uint16) error) error {
+	// If GUID table is used in the firmware, the footer GUID will be
+	// `FwGuidTableFooterGuid`. Make sure that the firmware is large
+	// enough to have the footer block.
+	footerOffsetFromEnd := baseOffsetFromEnd + abi.SizeofFwGUIDEntry
+	if len(firmware) < footerOffsetFromEnd {
+		return fmt.Errorf("firmware size is too small to copy the footer block")
+	}
+	if len(blockSizes) != len(populateFns) {
+		return fmt.Errorf("blockSizes and populateFns must have the same length")
+	}
+	var blockSize uint16
+	for i, populateFn := range populateFns {
+		if err := populateFn(uint16(footerOffsetFromEnd) + blockSize); err != nil {
+			return err
+		}
+		blockSize += blockSizes[i]
+	}
+	return (&abi.FwGUIDEntry{
+		GUID: uuid.MustParse(abi.FwGUIDTableFooterGUID),
+		// `footerBlock.size` will be the sum of the footer block and all the other
+		// blocks in the GUID table. For this test, an ES reset block and an SNP
+		// boot block are included in the GUID table.
+		Size: blockSize + abi.SizeofFwGUIDEntry,
+	}).Put(firmware[len(firmware)-footerOffsetFromEnd:])
+}
+
+// InitializeSevGUIDTable initializes the GUID table with the given reset block address and SNP
+// sections.
+func InitializeSevGUIDTable(
+	firmware []byte,
+	baseOffsetFromEnd int,
+	resetBlockAddr uint32,
+	snpSections []abi.SevMetadataSection) error {
+	return InitializeGUIDTable(firmware, baseOffsetFromEnd, []uint16{
+		abi.SizeofSevEsResetBlock,
+		abi.SizeofMetadataOffset,
+	}, InitializeSevGUIDTableFns(firmware, resetBlockAddr, snpSections))
+}
+
+// CleanExample returns an example "UEFI" binary that contains expected metadata.
+func CleanExample(t testing.TB, size int) []byte {
+	t.Helper()
+	if size < 0x1000 {
+		t.Fatalf("example size must be >= 0x1000")
+	}
+	firmware := make([]byte, size)
+	copy(firmware[0x800:], []byte("LGTMLGTMLGTMLGTM"))
+	copy(firmware[0xa00:], []byte("LGTMLGTMLGTMLGTM"))
+	tdxmeta := defaultTdxMetadata()
+	populateFns := append(
+		InitializeSevGUIDTableFns(firmware[:], SevEsAddrVal, DefaultSnpSections()),
+		InitializeTdxGUIDTableFns(firmware[:], tdxMetadataAddr, tdxmeta)...)
+	InitializeGUIDTable(firmware, abi.FwGUIDTableEndOffset, []uint16{
+		abi.SizeofSevEsResetBlock,
+		abi.SizeofMetadataOffset,
+		abi.SizeofMetadataOffset, // TDX metadata offset block (in reset vector).
+	}, populateFns)
+	return firmware
+}

--- a/testing/fakeovmf/fake_tdx_data.go
+++ b/testing/fakeovmf/fake_tdx_data.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakeovmf
+
+import (
+	"fmt"
+
+	"github.com/google/gce-tcb-verifier/ovmf/abi"
+	"github.com/google/uuid"
+)
+
+const (
+	tdxMetadataAddr = 0x100
+)
+
+func defaultTdxMetadata() *abi.TDXMetadata {
+	return &abi.TDXMetadata{
+		Header: &abi.TDXMetadataDescriptor{
+			Signature:    abi.TDXMetadataDescriptorMagic,
+			Length:       208,
+			Version:      abi.TDXMetadataVersion,
+			SectionCount: 6,
+		},
+		Sections: []*abi.TDXMetadataSection{
+			{
+				DataOffset:                 0x20000,
+				DataSize:                   0x1e0000,
+				MemoryBase:                 0xffe20000,
+				MemorySize:                 0x1e0000,
+				SectionType:                abi.TDXMetadataSectionTypeBFV,
+				MetadataAttributesExtendmr: 1,
+			},
+			{
+				DataSize:    0x20000,
+				MemoryBase:  0xffe00000,
+				MemorySize:  0x20000,
+				SectionType: abi.TDXMetadataSectionTypeCFV,
+			},
+			{
+				MemoryBase:  0x810000,
+				MemorySize:  0x10000,
+				SectionType: abi.TDXMetadataSectionTypeTempMem,
+			},
+			{
+				MemoryBase:  0x80b000,
+				MemorySize:  0x2000,
+				SectionType: abi.TDXMetadataSectionTypeTempMem,
+			},
+			{
+				MemoryBase:  0x809000,
+				MemorySize:  0x2000,
+				SectionType: abi.TDXMetadataSectionTypeTDHOB,
+			},
+			{
+				MemoryBase:  0x800000,
+				MemorySize:  0x6000,
+				SectionType: abi.TDXMetadataSectionTypeTempMem,
+			},
+		},
+	}
+}
+
+func initializeOvmfTdxMetadata(firmware []byte, baseOffsetFromEnd int, metadataOffset int, tdxMetadata *abi.TDXMetadata) error {
+	offsetFromEnd := baseOffsetFromEnd + abi.SizeofMetadataOffset
+	if len(firmware) == 0 || len(firmware) < offsetFromEnd {
+		return fmt.Errorf("the given firmware is too small to hold an OVMF metadata offset ending at baseOffsetFromEnd. buffer size: %d, OVMF metadata offset size: %d",
+			len(firmware), abi.SizeofMetadataOffset)
+	}
+	if err := abi.PutUUID(firmware[metadataOffset:], uuid.MustParse(abi.TDXMetadataGUID)); err != nil {
+		return err
+	}
+	if err := tdxMetadata.Put(firmware[metadataOffset+16:]); err != nil {
+		return err
+	}
+
+	// We generate the GUID-ed table entry and set it to point to the SEV
+	// Metadata with an offset calculated from the back.
+	guidTableOffset := abi.MetadataOffset{Offset: uint32(len(firmware) - metadataOffset - 16)}
+	guidTableOffset.GUIDEntry.GUID = uuid.MustParse(abi.TDXMetadataOffsetGUID)
+	guidTableOffset.GUIDEntry.Size = abi.SizeofMetadataOffset
+	return guidTableOffset.Put(firmware[len(firmware)-offsetFromEnd:])
+}
+
+// InitializeTdxGUIDTableFns creates a TDX GUID table containing the TDXMetadata to test helper
+// functions that search for and extract the TDXMetadata from `firmware`. `baseOffsetFromEnd` is the
+// offset from the end of the firmware where the footer GUID block will be initialized.
+func InitializeTdxGUIDTableFns(firmware []byte, tdxMetadataOffset int, tdxMetadata *abi.TDXMetadata) []func(uint16) error {
+	return []func(uint16) error{func(offset uint16) error {
+		return initializeOvmfTdxMetadata(firmware, int(offset), tdxMetadataOffset, tdxMetadata)
+	}}
+}

--- a/testing/nonprod/nonprod_test.go
+++ b/testing/nonprod/nonprod_test.go
@@ -35,11 +35,11 @@ import (
 	"github.com/google/gce-tcb-verifier/sign/memca"
 	"github.com/google/gce-tcb-verifier/sign/nonprod"
 	"github.com/google/gce-tcb-verifier/testing/devkeys"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/localca"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/localkm"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/localnonvcs"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/memkm"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/google/gce-tcb-verifier/testing/testkm"
 	"github.com/google/gce-tcb-verifier/testing/testsign"
 	"github.com/google/go-cmp/cmp"
@@ -53,7 +53,7 @@ import (
 const mb = 1024 * 1024
 
 var (
-	fwBytes  = ovmfsev.CleanExample(&testing.T{}, 2*mb)
+	fwBytes  = fakeovmf.CleanExample(&testing.T{}, 2*mb)
 	fwDigest = sha512.Sum384(fwBytes)
 )
 

--- a/verify/verifytest/verifytest.go
+++ b/verify/verifytest/verifytest.go
@@ -27,9 +27,9 @@ import (
 	"github.com/google/gce-tcb-verifier/sign/memca"
 	"github.com/google/gce-tcb-verifier/sign/nonprod"
 	"github.com/google/gce-tcb-verifier/testing/devkeys"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/localnonvcs"
 	"github.com/google/gce-tcb-verifier/testing/nonprod/memkm"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/google/gce-tcb-verifier/testing/testsign"
 )
 
@@ -38,9 +38,9 @@ const (
 	SignKey = "projects/testProject/locations/us-west1/keyRings/gce-cc-ring/cryptoKeys/gce-uefi-signer/cryptoKeyVersions/1"
 	// CleanExampleMeasurement is the hex encoding of a 2MiB 1 VMSA measurement of the CleanExample
 	// firmware binary.
-	CleanExampleMeasurement = "2247cc90eae3eff72c8d4b4ea5fefb8914bd80ad093859d5d022332eba7c7abe59e13d525c941ede5541191d7149585d"
+	CleanExampleMeasurement = "20ec0dbd1c0a26d184a6f11ec5a796d68ec03c9d101bdd84c03f3d9cbbc4a292a9fad098edacfa04da0da58f20be885e"
 	// CleanExampleURL is the URL of the endorsement of the CleanExample firmware binary.
-	CleanExampleURL = "https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/2247cc90eae3eff72c8d4b4ea5fefb8914bd80ad093859d5d022332eba7c7abe59e13d525c941ede5541191d7149585d.binarypb"
+	CleanExampleURL = "https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/20ec0dbd1c0a26d184a6f11ec5a796d68ec03c9d101bdd84c03f3d9cbbc4a292a9fad098edacfa04da0da58f20be885e.binarypb"
 )
 
 // FakeData encapsulates resources needed for testing UEFI endorsement verification.
@@ -89,7 +89,7 @@ func FakeEndorsement(t testing.TB) []byte {
 	dir := t.TempDir()
 	c := cmd.Compose(memkm.TestOnlyT(), memca.TestOnlyCertificateAuthority(), &localnonvcs.T{Root: dir})
 	app := cmd.MakeApp(context.Background(), &cmd.AppComponents{Endorse: c})
-	fw := ovmfsev.CleanExample(t, 2*1024*1024)
+	fw := fakeovmf.CleanExample(t, 2*1024*1024)
 	fwPath := path.Join(dir, "ovmf_x64_csm.fd")
 	if err := os.WriteFile(fwPath, fw, 0644); err != nil {
 		t.Fatal(err)

--- a/verify/verifytest/verifytest_test.go
+++ b/verify/verifytest/verifytest_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/google/gce-tcb-verifier/sign/nonprod"
 	"github.com/google/gce-tcb-verifier/sign/ops"
 	styp "github.com/google/gce-tcb-verifier/sign/types"
+	"github.com/google/gce-tcb-verifier/testing/fakeovmf"
 	"github.com/google/gce-tcb-verifier/testing/match"
-	"github.com/google/gce-tcb-verifier/testing/ovmfsev"
 	"github.com/google/gce-tcb-verifier/timeproto"
 	"github.com/google/gce-tcb-verifier/verify"
 	"github.com/google/go-sev-guest/abi"
@@ -86,8 +86,8 @@ func TestVerify(t *testing.T) {
 	if _, err := rnd.Read(uefi); err != nil {
 		t.Fatalf("could not populate uefi: %v", err)
 	}
-	if err := ovmfsev.InitializeSevGUIDTable(uefi[:], oabi.FwGUIDTableEndOffset, ovmfsev.SevEsAddrVal, ovmfsev.DefaultSnpSections()); err != nil {
-		t.Fatalf("ovmfsev.InitializeSevGUIDTable() errored unexpectedly: %v", err)
+	if err := fakeovmf.InitializeSevGUIDTable(uefi[:], oabi.FwGUIDTableEndOffset, fakeovmf.SevEsAddrVal, fakeovmf.DefaultSnpSections()); err != nil {
+		t.Fatalf("fakeovmf.InitializeSevGUIDTable() errored unexpectedly: %v", err)
 	}
 
 	uefidigest := sha512.Sum384(uefi)
@@ -269,7 +269,7 @@ func TestSNPValidateFunc(t *testing.T) {
 				Kind: validate.CertEntryRequire,
 				Validate: verify.SNPValidateFunc(&verify.Options{SNP: &verify.SNPOptions{}, Getter: &stest.Getter{
 					Responses: map[string][]stest.GetResponse{
-						"https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/2247cc90eae3eff72c8d4b4ea5fefb8914bd80ad093859d5d022332eba7c7abe59e13d525c941ede5541191d7149585d.binarypb": {{Error: fmt.Errorf("nope to that")}},
+						"https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/20ec0dbd1c0a26d184a6f11ec5a796d68ec03c9d101bdd84c03f3d9cbbc4a292a9fad098edacfa04da0da58f20be885e.binarypb": {{Error: fmt.Errorf("nope to that")}},
 					},
 				}}),
 			},
@@ -284,7 +284,7 @@ func TestSNPValidateFunc(t *testing.T) {
 					RootsOfTrust: rot,
 					Getter: &stest.Getter{
 						Responses: map[string][]stest.GetResponse{
-							"https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/2247cc90eae3eff72c8d4b4ea5fefb8914bd80ad093859d5d022332eba7c7abe59e13d525c941ede5541191d7149585d.binarypb": {{Body: FakeEndorsement(t)}},
+							"https://storage.googleapis.com/gce_tcb_integrity/ovmf_x64_csm/sevsnp/20ec0dbd1c0a26d184a6f11ec5a796d68ec03c9d101bdd84c03f3d9cbbc4a292a9fad098edacfa04da0da58f20be885e.binarypb": {{Body: FakeEndorsement(t)}},
 						},
 					}}),
 			},


### PR DESCRIPTION
Needed for further testing of parsing. The "CleanExample" now includes TDVF metadata and therefore changes all the precomputed measurements.