### PR TITLE
Fix endorsement handling in `sev validate`

### DIFF
--- a/gcetcbendorsement/cmd/root.go
+++ b/gcetcbendorsement/cmd/root.go
@@ -26,7 +26,9 @@ import (
 	"github.com/google/gce-tcb-verifier/extract"
 	exel "github.com/google/gce-tcb-verifier/extract/eventlog"
 	"github.com/google/gce-tcb-verifier/verify"
+	"github.com/google/go-sev-guest/client"
 	"github.com/google/go-sev-guest/verify/trust"
+	"github.com/google/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -95,8 +97,13 @@ func (b *bearerGetter) Get(url string) ([]byte, error) {
 
 func init() {
 	var bearer string
+	var timeout time.Duration
+	p, err := client.GetQuoteProvider()
+	if err != nil {
+		logger.Fatalf("Failed to get quote provider: %v", err)
+	}
 	RootCmd = MakeRoot(context.WithValue(context.Background(), backendKey, &Backend{
-		Provider: &extract.ConfigfsTsmQuoteProvider{},
+		Provider: p,
 		Getter: &trust.RetryHTTPSGetter{
 			Timeout:       2 * time.Minute,
 			MaxRetryDelay: 30 * time.Second,
@@ -109,13 +116,14 @@ func init() {
 		IO:  OSIO{},
 	}))
 	RootCmd.PersistentFlags().StringVar(&bearer, "auth_token", "", "Bearer token to use for HTTP requests.")
+	RootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 2*time.Minute, "Timeout for HTTPS GET requests")
 	RootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if bearer == "" {
 			return
 		}
 		b, _ := backendFrom(cmd.Context())
 		b.Getter = &trust.RetryHTTPSGetter{
-			Timeout:       2 * time.Minute,
+			Timeout:       timeout,
 			MaxRetryDelay: 30 * time.Second,
 			Getter:        &bearerGetter{token: bearer},
 		}

--- a/gcetcbendorsement/sevvalidate.go
+++ b/gcetcbendorsement/sevvalidate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/gce-tcb-verifier/cmd/output"
 	"github.com/google/gce-tcb-verifier/extract/extractsev"
 	epb "github.com/google/gce-tcb-verifier/proto/endorsement"
 	"github.com/google/gce-tcb-verifier/sev"
@@ -84,6 +85,7 @@ func SevValidate(ctx context.Context, attestation *spb.Attestation, opts *SevVal
 	var err error
 	endorsement := opts.Endorsement
 	if endorsement == nil {
+		output.Infof(ctx, "Extracting endorsement from attestation")
 		endorsement, err = extractEndorsement(attestation, opts)
 		if err != nil {
 			return err
@@ -110,6 +112,7 @@ func SevValidate(ctx context.Context, attestation *spb.Attestation, opts *SevVal
 				RootsOfTrust: opts.RootsOfTrust,
 				Now:          opts.Now,
 				Getter:       opts.Getter,
+				Endorsement:  endorsement,
 			})},
 	}
 	return validate.SnpAttestation(attestation, vopts)

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -42,6 +42,8 @@ var (
 	ErrNoSevSnpMeasurements = errors.New("golden measurement does not have SEV-SNP measurements")
 	// ErrNoEndorsementCert is returned when a launch endorsement's Cert field is empty.
 	ErrNoEndorsementCert = errors.New("endorsement certificate is empty")
+	// ErrNoRootsOfTrust is returned when endorsement signature verification is not given any roots of trust.
+	ErrNoRootsOfTrust = errors.New("endorsement certificate roots of trust are empty")
 	// Provenance information was lost between January and May due to a change in the release process.
 	// Signing time differs from release candidate cut time, so the April release still has signatures
 	// from June. Set a start date of July 1, 2024.
@@ -218,6 +220,9 @@ func SNP(golden *epb.VMGoldenMeasurement, opts *SNPOptions) error {
 func CheckCertificate(certder []byte, rootsOfTrust *x509.CertPool, now time.Time) (*x509.Certificate, error) {
 	if len(certder) == 0 {
 		return nil, ErrNoEndorsementCert
+	}
+	if rootsOfTrust == nil {
+		return nil, ErrNoRootsOfTrust
 	}
 	cert, err := x509.ParseCertificate(certder)
 	if err != nil {


### PR DESCRIPTION
The endorsement can be passed in as an argument, but the validation function would still try to fetch an endorsement from the network. If the endorsement is provided, use it instead of using the network fallback.