### PR TITLE
Reword error message in CheckCertificate cert.Verify

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -231,7 +231,7 @@ func CheckCertificate(certder []byte, rootsOfTrust *x509.CertPool, now time.Time
 		return nil, fmt.Errorf("could not parse certificate: %v", err)
 	}
 	if _, err := cert.Verify(x509.VerifyOptions{Roots: rootsOfTrust, CurrentTime: now}); err != nil {
-		return nil, fmt.Errorf("key %v was not signed by a root of trust: %v", cert.Subject, err)
+		return nil, fmt.Errorf("could not verify key with subject %q has a valid signature from a root of trust: %v", cert.Subject, err)
 	}
 	return cert, nil
 }

--- a/verify/verifytest/verifytest_test.go
+++ b/verify/verifytest/verifytest_test.go
@@ -217,7 +217,7 @@ func TestVerify(t *testing.T) {
 			endorsement: endorsement,
 			pool:        badpool,
 			snp:         &verify.SNPOptions{},
-			wantErr:     "was not signed by a root of trust",
+			wantErr:     "could not verify key with subject",
 		},
 		{
 			name:        "no cert",


### PR DESCRIPTION
While debugging a test failure that originates from this method, I came across the following error message:

key SERIALNUMBER=2,CN=gce-uefi-signer,OU=Engineering,O=Google,L=Kirkland,ST=WA,C=USA was not signed by a root of trust: x509: certificate has expired or is not yet valid: current time 2024-09-03T03:33:55Z is after 2024-09-01T16:21:32Z

This error message implies that the certificate being checked wasn't signed by the root, but in fact there is an issue with certificate expiration.

Reworded this message to be less specific to better encapsulate possible failures. This specific failure would now read:

could not verify key with subject SERIALNUMBER=2,CN=gce-uefi-signer,OU=Engineering,O=Google,L=Kirkland,ST=WA,C=USA was signed by a root of trust: x509: certificate has expired or is not yet valid: current time 2024-09-03T03:33:55Z is after 2024-09-01T16:21:32Z, want ""

This is also inclusive of the actual failure behind this error where the cert that's being check is itself invalid.