### PR TITLE
Fix the option for enabling the old buggy behavior

### DIFF
--- a/ovmf/tdx_data.go
+++ b/ovmf/tdx_data.go
@@ -368,7 +368,7 @@ func (p *tdxFwParser) getTDHOBList(privateResources []GuestPhysicalRegion, unacc
 // ExtractMaterialGuestPhysicalRegionsNoUnacceptedMemory extracts the TDX guest physical regions from
 // the firmware binary with the direction that all memory will be accepted early in the firmware.
 func ExtractMaterialGuestPhysicalRegionsNoUnacceptedMemory(firmware []byte, guestRAMbanks []GuestPhysicalRegion) ([]*MaterialGuestPhysicalRegion, error) {
-	return (&tdxFwParser{}).parse(firmware, guestRAMbanks)
+	return (&tdxFwParser{MeasureAllRegions: true}).parse(firmware, guestRAMbanks)
 }
 
 // ExtractMaterialGuestPhysicalRegionsTDHOBBug extracts the TDX guest physical regions from the

--- a/tdx/endorsement.go
+++ b/tdx/endorsement.go
@@ -50,11 +50,11 @@ func generateAllPossibleMRTDs(uefi []byte, tdxRequest *EndorsementRequest) ([]*e
 		})
 		if tdxRequest.IncludeEarlyAccept {
 			options.DisableUnacceptedMemory = true
-			meas, _ = MRTD(options, uefi)
+			meas2, _ := MRTD(options, uefi)
 			result = append(result, &epb.VMTdx_Measurement{
 				RamGib:      uint32(shapeDesc[shape].size),
 				EarlyAccept: true,
-				Mrtd:        meas[:],
+				Mrtd:        meas2[:],
 			})
 		}
 	}

--- a/tdx/mrtd_from_ovmf.go
+++ b/tdx/mrtd_from_ovmf.go
@@ -117,11 +117,11 @@ func MRTD(opts *LaunchOptions, fw []byte) ([48]byte, error) {
 	} else {
 		m = NewMeasurement()
 	}
-	if opts.MeasureAllRegions {
-		regions, err = ovmf.ExtractMaterialGuestPhysicalRegionsTDHOBBug(fw, opts.GuestRAMBanks)
-	} else if opts.DisableUnacceptedMemory {
+	if opts.DisableUnacceptedMemory {
 		regions, err = ovmf.ExtractMaterialGuestPhysicalRegionsNoUnacceptedMemory(
 			fw, opts.GuestRAMBanks)
+	} else if opts.MeasureAllRegions {
+		regions, err = ovmf.ExtractMaterialGuestPhysicalRegionsTDHOBBug(fw, opts.GuestRAMBanks)
 	} else {
 		regions, err = ovmf.ExtractMaterialGuestPhysicalRegions(fw)
 	}


### PR DESCRIPTION
I got the conditions swapped around. With this I can calculate the digest that's getting the prod 404 on GCS fallback for c3-standard-88.