### PR TITLE
Update CI golang versions to ubuntu-latest-supported versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest]
 
     name: Build/Test (${{ matrix.os}}, Go ${{ matrix.go-version }})
@@ -61,7 +61,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
 
     name: Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})
@@ -93,7 +93,7 @@ jobs:
   lintc:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
 
     name: Lint CGO (${{ matrix.os}}, Go ${{ matrix.go-version }})


### PR DESCRIPTION
The update to ubuntu2404 deprecated some older runtimes.