### PR TITLE
Remove SnapshotToHead

### DIFF
--- a/cmd/endorse.go
+++ b/cmd/endorse.go
@@ -94,8 +94,6 @@ func (f *endorseCommand) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSliceVar(&ec.Tdx.MachineShapes, "tdx_machine_shapes", nil, "DEPRECATED (VMM before Oct 2024): GCE machine shapes whose measurement-relevant configuration should be enumerated for endorsement.")
 	cmd.PersistentFlags().BoolVar(&ec.MeasurementOnly, "measurement_only", false, "Only output the OVMF measurement for added technologies.")
 	cmd.PersistentFlags().StringVar(&ec.SnapshotDir, "snapshot_dir", "", "Write each firmware and its signature to related files in --out_dir.")
-	cmd.PersistentFlags().BoolVar(&ec.SnapshotToHead, "snapshot_to_head", false,
-		"Write snapshots to HEAD, not the release branch.")
 	cmd.SetContext(endorse.NewContext(cmd.Context(), ec))
 }
 

--- a/endorse/endorse.go
+++ b/endorse/endorse.go
@@ -71,10 +71,6 @@ type Context struct {
 	// to the VCS with related paths. This is in addition to the manifest method to allow for older
 	// releases to still get signatures in a way the VMM can parse.
 	SnapshotDir string
-	// SnapshotToHead is true if the snapshot should be written to HEAD instead of the release branch.
-	// This is an interim solution until the firmware is entirely in its own separately released
-	// package.
-	SnapshotToHead bool
 	// ImageName is the path under SnapshotDir to write the firmware and its endorsement.
 	ImageName string
 	// SvsmImage is the full contents of the SVSM IGVM, if supplied.


### PR DESCRIPTION
Unused. Downstream VCS users must add the flag themselves.